### PR TITLE
Don't curtail X509 proxy lifetime in DAGs

### DIFF
--- a/templates/dag/dag.dag.condor.sub
+++ b/templates/dag/dag.dag.condor.sub
@@ -26,6 +26,7 @@ environment	=  _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"
 x509userproxy = {{proxy}}
+delegate_job_GSI_credentials_lifetime = 0
 {{lines|join("\n")}}
 
 {% if subgroup is defined and subgroup %}
@@ -42,7 +43,5 @@ use_oauth_services = {{group}}_{{role}}
 {% else %}
 use_oauth_services = {{group}}
 {% endif %}
-
-x509userproxy = {{proxy}}
 
 queue

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -58,6 +58,7 @@ use_oauth_services = {{group}}
 {% endif %}
 {% if role is defined %}
 +x509userproxy = "{{proxy|basename}}"
+delegate_job_GSI_credentials_lifetime = 0
 {% endif %}
 
 queue 1

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -59,6 +59,7 @@ use_oauth_services = {{group}}
 {% endif %}
 {% if role is defined %}
 +x509userproxy = "{{proxy|basename}}"
+delegate_job_GSI_credentials_lifetime = 0
 {% endif %}
 
 queue 1

--- a/templates/dataset_dag/dataset.dag.condor.sub
+++ b/templates/dataset_dag/dataset.dag.condor.sub
@@ -45,6 +45,7 @@ use_oauth_services = {{group}}
 {% endif %}
 {% if role is defined %}
 +x509userproxy = "{{proxy}}"
+delegate_job_GSI_credentials_lifetime = 0
 {% endif %}
 
 queue


### PR DESCRIPTION
This closes #179, implementing the JDF classad attribute needed to not curtail X509 proxy lifetime in DAGs.  We already did this for regular jobs in #186.

@marcmengel - could you please test this on a dataset DAG?  I did already for a regular DAG, but I'd like to make sure this doesn't break more complex stuff.  Thanks!