### PR TITLE
Made args_for_schedd into a defaultdict because we always expect list values

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -23,6 +23,7 @@
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 
 import argparse
+from collections import defaultdict
 import os
 import sys
 import re
@@ -103,7 +104,7 @@ def main() -> None:
     execargs = []
     schedd_list = set()
     # save beginning of 1234@schedd in list of args for that schedd
-    args_for_schedd = {}
+    args_for_schedd = defaultdict(list)
 
     if arglist.name:
         schedd = arglist.name
@@ -115,13 +116,11 @@ def main() -> None:
         m = re.match(r"([\d.]*)@([\w.]+)", i)
         if m:
             # looks like a jobsub id 12.34@schedd.name
-            schedd_list.add(m.group(2))
-            if m.group(1):
-                jobid = m.group(1).strip(".")
-                if not m.group(2) in args_for_schedd:
-                    args_for_schedd[m.group(2)] = [jobid]
-                else:
-                    args_for_schedd[m.group(2)].append(jobid)
+            match_jobid, match_schedd = m.groups()
+            schedd_list.add(match_schedd)
+            if match_jobid:
+                jobid = match_jobid.strip(".")
+                args_for_schedd[match_schedd].append(jobid)
             continue
 
         # convert --better-analyze to -better-analyze, etc.


### PR DESCRIPTION
Just a quick change I thought about after reviewing #405.  Since we always expect a list in `args_for_schedds`, rather than do a check for schedd membership in that dict, we can simply make it a default dict which will add the key automatically if it doesn't exist.

Tested this doesn't break anything (and still solves #370, like #405 did) with the following:

```
 ~/jobsub_lite/bin/jobsub_submit -G fermilab --debug -N 20 --devserver file:///usr/bin/sleep 300
 ~/jobsub_lite/bin/jobsub_q -G fermilab --devserver --jobid=11420.0@jobsubdevgpvm01.fnal.gov
 ~/jobsub_lite/bin/jobsub_rm -G fermilab --devserver --debug --jobid=11420.@jobsubdevgpvm01.fnal.gov
```