### PR TITLE
Do not try to be too helpful with vault tokens

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -71,9 +71,6 @@ def submit_vt(
                     os.rename(vtname, f"{vtname}.{pid}")
                 os.rename(schedvtname, vtname)
 
-            if not os.path.exists(vtname) and os.path.exists(plainvtname):
-                shutil.copy(plainvtname, vtname)
-
             if verbose > 1:
                 print("vault tokens after pre-submit renaming:")
                 os.system(f"ls -l {tmp}/vt_u{uid}*")


### PR DESCRIPTION

Do *not* copy `/tmp/vt_u$(id -u) ` to ` /tmp/vt_u($(id-u)_group-Role` because it confuses condor_vault_storer,
which uses the latter file to keep track of when it uploads to the credmon...