### PR TITLE
If user tries to use --tar-file-name with a file that is not a tar archive, raise error advising user to switch to -f flag instead

### DIFF
--- a/lib/skip_checks.py
+++ b/lib/skip_checks.py
@@ -43,7 +43,7 @@ def _print_rcds_warning() -> None:
         "directory using RCDS/CVMFS, the uploaded tarball is published "
         "on CVMFS before the job is submitted.  Skipping this check "
         "may result in jobs running on the worker nodes that cannot "
-        "find the intended uploaded files."
+        "find the intended uploaded files.\n"
     )
 
 

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tarfile as tarfile_mod
 import time
 import tempfile
 import pathlib
@@ -247,3 +248,17 @@ class TestTarfilesUnit:
         f = FakePublisherHandler(cid=fake_cid)
         assert f.fail_function() is None
         assert f.present_function() == fake_location
+
+    @pytest.mark.unit
+    def test_tarchmod_not_tarfile(self, tmp_path):
+        """Test that if we give tarchmod a file that is not a tarfile to
+        operate on, it raises the appropriate error"""
+        # Make a temp file with some content in it that is not a tarball
+        CONTENT = "This is a fake temp file, not a tar archive"
+        tmp_file = tmp_path / "test_file.txt"
+        tmp_file.write_text(CONTENT)
+        assert tmp_file.read_text() == CONTENT
+
+        # The actual test
+        with pytest.raises(tarfile_mod.TarError):
+            tarfiles.tarchmod(str(tmp_file))


### PR DESCRIPTION
Closes #364 