### PR TITLE
Add --schedd-for-testing flag

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -133,8 +133,6 @@ def get_schedd_list(vargs: Dict[str, Any]) -> List[classad.ClassAd]:
     if vargs.get("verbose", 0) > 1:
         print(f"post-query schedd classads: {schedds} ")
 
-        print("")
-
     return schedds
 
 

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -182,6 +182,12 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
         help="jobsub_lite support email",
         default=False,
     )
+    parser.add_argument(
+        "--schedd-for-testing",  # Non-advertised option for testers to direct jobs to certain schedds
+        type=str,
+        action=CheckIfValidSchedd,
+        help=argparse.SUPPRESS,
+    )
     return parser
 
 
@@ -447,12 +453,6 @@ def get_parser() -> argparse.ArgumentParser:
         " example: --resource-provides=CVMFS=OSG will add"
         ' +DESIRED_CVMFS="OSG" to the job classad attributes and'
         " '&&(CVMFS==\"OSG\")' to the job requirements",
-    )
-    parser.add_argument(
-        "--schedd-for-testing",  # Non-advertised option for testers to direct jobs to certain schedds
-        type=str,
-        action=CheckIfValidSchedd,
-        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--skip-check",


### PR DESCRIPTION
Closes #421 

I also changed the `condor_status -schedd` code to use a jinja template, since the logic with this added feature was getting a bit tougher to parse.


Tested with no schedd specified, a couple of our real schedds, and a fake schedd.  Jobs were properly directed to the requested schedd, or the submission rejected in the case of the fake schedd.  All jobs (`sleep 300`) succeeded.

Also, ran all unit tests, which pass.