### PR TITLE
Fix bug where passing -name to jobsub_cmd commands gets ignored and we look at all schedds

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -107,7 +107,7 @@ def main() -> None:
     args_for_schedd = defaultdict(list)
 
     if arglist.name:
-        schedd = arglist.name
+        schedd_list.add(arglist.name)
 
     default_formatting = True
     default_constraint = True


### PR DESCRIPTION
In working on #424, with @marcmengel's suggestion there that we allow for choosing a schedd for `jobsub_q`, etc. queries, I found a bug with the way that the `jobsub_cmd`-derived commands (`jobsub_q`, `jobsub_hold`, etc.) handle the `-name` flag - namely that it's ignored.

For example, this was the previous behavior:

```
$ ~/jobsub_lite/bin/jobsub_q -G fermilab -name jobsub01.fnal.gov sbhat
JOBSUBJOBID                             OWNER           SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
61563115.0@jobsub01.fnal.gov            sbhat           05/10 16:46   0+00:00:08 C    0    0.0 simple.sh 
61859314.0@jobsub01.fnal.gov            sbhat           05/19 19:50   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
61863900.0@jobsub01.fnal.gov            sbhat           05/20 02:38   0+00:00:00 I    0    0.0 sleep 300
688176.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:19:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
688179.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
770273.0@jobsub04.fnal.gov              sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
68343522.0@jobsub02.fnal.gov            sbhat           05/11 16:10   0+00:17:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
503632.0@jobsub05.fnal.gov              sbhat           05/11 16:10   0+00:01:07 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
677046.0@jobsub05.fnal.gov              sbhat           05/19 19:50   0+00:18:43 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
681222.0@jobsub05.fnal.gov              sbhat           05/20 02:37   0+00:00:00 R    0    0.0 sleep 300
```

Rather than filtering for jobs running from the `jobsub01.fnal.gov` schedd, it shows all jobs.

This PR solves that issue, and I tested with `jobsub_q`, `jobsub_hold`, `jobsub_release`, and `jobsub_rm`:

```
$ ~/jobsub_lite/bin/jobsub_q -G fermilab -name jobsub04.fnal.gov sbhat
JOBSUBJOBID                             OWNER           SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
688176.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:19:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
688179.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
$ ~/jobsub_lite/bin/jobsub_hold -G fermilab -name jobsub05.fnal.gov sbhat
All jobs of user "sbhat" have been held

# Note the held job on jobsub05, and the running jobs on jobsub04 and jobsub01
$ ~/jobsub_lite/bin/jobsub_q -G fermilab sbhat   
JOBSUBJOBID                             OWNER           SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
503632.0@jobsub05.fnal.gov              sbhat           05/11 16:10   0+00:01:07 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
677046.0@jobsub05.fnal.gov              sbhat           05/19 19:50   0+00:18:43 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
681222.0@jobsub05.fnal.gov              sbhat           05/20 02:37   0+00:00:00 H    0    0.0 sleep 300
688176.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:19:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
688179.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
770273.0@jobsub04.fnal.gov              sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
61563115.0@jobsub01.fnal.gov            sbhat           05/10 16:46   0+00:00:08 C    0    0.0 simple.sh 
61859314.0@jobsub01.fnal.gov            sbhat           05/19 19:50   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
61863900.0@jobsub01.fnal.gov            sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
68343522.0@jobsub02.fnal.gov            sbhat           05/11 16:10   0+00:17:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
$ ~/jobsub_lite/bin/jobsub_release -G fermilab -name jobsub05.fnal.gov sbhat
All jobs of user "sbhat" have been released

# Now, the previously-held job on jobsub05 has been released
$ ~/jobsub_lite/bin/jobsub_q -G fermilab sbhat  
JOBSUBJOBID                             OWNER           SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
503632.0@jobsub05.fnal.gov              sbhat           05/11 16:10   0+00:01:07 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
677046.0@jobsub05.fnal.gov              sbhat           05/19 19:50   0+00:18:43 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
681222.0@jobsub05.fnal.gov              sbhat           05/20 02:37   0+00:00:00 I    0    0.0 sleep 300
61563115.0@jobsub01.fnal.gov            sbhat           05/10 16:46   0+00:00:08 C    0    0.0 simple.sh 
61859314.0@jobsub01.fnal.gov            sbhat           05/19 19:50   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
61863900.0@jobsub01.fnal.gov            sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
688176.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:19:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
688179.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
770273.0@jobsub04.fnal.gov              sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
68343522.0@jobsub02.fnal.gov            sbhat           05/11 16:10   0+00:17:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
$ ~/jobsub_lite/bin/jobsub_rm -G fermilab -name jobsub05.fnal.gov sbhat
All jobs of user "sbhat" have been marked for removal

# Note below - the jobsub05 jobs are either gone or marked for removal
$ ~/jobsub_lite/bin/jobsub_q -G fermilab sbhat
JOBSUBJOBID                             OWNER           SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
688176.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:19:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
688179.0@jobsub04.fnal.gov              sbhat           05/16 16:15   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
770273.0@jobsub04.fnal.gov              sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
61563115.0@jobsub01.fnal.gov            sbhat           05/10 16:46   0+00:00:08 C    0    0.0 simple.sh 
61859314.0@jobsub01.fnal.gov            sbhat           05/19 19:50   0+00:00:22 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
61863900.0@jobsub01.fnal.gov            sbhat           05/20 02:38   0+00:00:00 R    0    0.0 sleep 300
681222.0@jobsub05.fnal.gov              sbhat           05/20 02:37   0+00:00:00 X    0    0.0 sleep 300
68343522.0@jobsub02.fnal.gov            sbhat           05/11 16:10   0+00:17:53 C    0    0.0 dagman_wrapper.sh -p 0 -f -l . -Lockfi
```