### PR TITLE
Store schedd ads in memory via global variable; give more user-friendly error message if MAX_PROCS_PER_SUBMISSION exceeded

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -490,12 +490,19 @@ def generate_error_message_for_too_many_procs(
     """
     Number of submitted jobs > MAX_JOBS_PER_SUBMISSION, so generate an error message for that
     """
+    default_msg = (
+        "There was an error obtaining the MAX_JOBS_PER_SUBMISSION from the schedd. "
+        "Please try breaking up your submission into clusters with fewer jobs."
+    )
     try:
         limit = __schedd_ads[schedd_name].eval("Jobsub_Max_Jobs_Per_Submission")
     except (AttributeError, KeyError):
         # For whatever reason, get_schedd_list was never called before calling submit
         get_schedd_list(vargs, refresh_schedd_ads=True)
         limit = __schedd_ads[schedd_name].eval("Jobsub_Max_Jobs_Per_Submission")
+    except ValueError:
+        # The classad exists but doesn't have this attribute at all.  Fall back to default
+        return default_msg
 
     try:
         msg = (
@@ -504,8 +511,6 @@ def generate_error_message_for_too_many_procs(
             f"Please break up your submission into clusters with at most {limit} jobs each."
         )
     except NameError:
-        msg = (
-            "There was an error obtaining the MAX_JOBS_PER_SUBMISSION from the schedd. "
-            "Please try breaking up your submission into clusters with fewer jobs."
-        )
+        return default_msg
+
     return msg

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -126,6 +126,29 @@ class TestCondorUnit:
         assert schedd["Name"] == TestUnit.test_schedd
 
     @pytest.mark.unit
+    def test_get_schedd_list_cache(self, capsys):
+        """Call get_schedd_list twice. The first time, we should get the
+        schedd ads from the collector.  The second time, it should come
+        from cache.  Call it a third time, and force the refresh."""
+        vargs = TestUnit.test_vargs
+        vargs["verbose"] = 2
+
+        # First time:  We should query collector
+        condor.get_schedd_list(vargs)
+        captured = capsys.readouterr()
+        assert "Querying condor collector" in captured.out
+
+        # Second time: We should query cache
+        condor.get_schedd_list(vargs)
+        captured = capsys.readouterr()
+        assert "Using cached schedd ads - NOT querying condor collector" in captured.out
+
+        # Third time: Force re-querying of collector
+        condor.get_schedd_list(vargs, refresh_schedd_ads=True)
+        captured = capsys.readouterr()
+        assert "Querying condor collector" in captured.out
+
+    @pytest.mark.unit
     def test_load_submit_file_1(self, get_submit_file):
         """make sure load_submit_file result has bits of the submit file"""
         res = condor.load_submit_file(get_submit_file)


### PR DESCRIPTION
Closes #367 

Along with fixing #367, I realized that for this, and possibly other cases, we're making multiple calls to the collector to get schedd info, where we really only need that once, since we don't retain state between executable runs.  For that reason, I also changed `get_schedd_list` to write to a global var, `__schedd_ads`, which is simply a dict of `schedd_name: schedd_ad`.  `get_schedd_list` then checks if this dictionary is populated before querying the collector.  If it does need to query the collector (and this can be forced via a new argument to the function), it will populate `__schedd_ads` as well.

Other functions inside the `condor.py` module can then also use this global variable to query schedd ads, which is what I use here to get the `Jobsub_Max_Procs_Per_Submission` attribute from the applicable schedd.

I generally try to stay away from globals, but I think in this case, it makes sense.