### PR TITLE
implements #440

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -274,6 +274,13 @@ def main():
 
     varg = vars(args)
 
+    if args.maxConcurrent and int(args.maxConcurrent) > args.N:
+        if args.verbose:
+            sys.stderr.write(
+                f"Note: ignoring --maxConcurrent {args.maxConcurrent} for {args.N} jobs\n"
+            )
+        args.maxConcurrent = None
+
     proxy, token = get_creds(varg)
 
     if args.verbose:

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -274,7 +274,7 @@ def main():
 
     varg = vars(args)
 
-    if args.maxConcurrent and int(args.maxConcurrent) > args.N:
+    if args.maxConcurrent and int(args.maxConcurrent) >= args.N and not args.dag:
         if args.verbose:
             sys.stderr.write(
                 f"Note: ignoring --maxConcurrent {args.maxConcurrent} for {args.N} jobs\n"

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -272,14 +272,14 @@ def main():
 
     do_tarballs(args)
 
-    varg = vars(args)
-
     if args.maxConcurrent and int(args.maxConcurrent) >= args.N and not args.dag:
         if args.verbose:
             sys.stderr.write(
                 f"Note: ignoring --maxConcurrent {args.maxConcurrent} for {args.N} jobs\n"
             )
         args.maxConcurrent = None
+
+    varg = vars(args)
 
     proxy, token = get_creds(varg)
 


### PR DESCRIPTION
Just a little logic check: if the --maxConcurrent value is greater than -N for how many jobs, just drop it. 
I'm doing this in jobsub_submit, just after we 