### PR TITLE
Clean env vs dash e

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -305,17 +305,35 @@ def set_extras_n_fix_units(
     fix_unit(args, "expected_lifetime", timtable, -1, "smhd", -1)
     fix_unit(args, "timeout", timtable, -1, "smhd", -1)
     newe = []
+    envnames = set()  # set of environment variable names with -e for below
     for e in args["environment"]:
         pos = e.find("=")
         if pos < 0:
+            envnames.add(e)
             v = os.environ.get(e, None)
             if not v:
                 raise RuntimeError(
                     f"--environment {e} was given but no value was in the environment"
                 )
             e = f"{e}={v}"
+        else:
+            envnames.add(e[0:pos])
+
         newe.append(e)
+
     args["environment"] = newe
+
+    #
+    # build list of environment variables for wrapper script to clear:
+    # -- this is our default list, below, minus anything passed in a -e/--environment argument
+    #
+    full_clean_env_list = ["LC_CTYPE", "CPATH", "LIBRARY_PATH"]
+    clean_env_list = []
+    for ev in full_clean_env_list:
+        if ev not in envnames:
+            clean_env_list.append(ev)
+    args["clean_env_vars"] = " ".join(clean_env_list)
+
     if args["verbose"] > 1:
         sys.stderr.write(f"leaving set_extras... args: {repr(args)}\n")
     args["jobsub_command"] = " ".join(sys.argv)

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -12,7 +12,7 @@ umask 002
 # clear out variables that sometimes bleed into containers
 # causing problems.  See for example INC000001136681...
 #
-for env_var in CPATH LIBRARY_PATH
+for env_var in {{clean_env_vars}}
 do
    eval unset $env_var
 done

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,3 +2,4 @@
 markers=
   unit
   integration
+  smoke

--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -213,8 +213,13 @@ def lookaround_launch(extra, verify_files=""):
     )
 
 
-@pytest.mark.integration
+@pytest.mark.smoke
 def test_launch_lookaround_samdev(samdev):
+    lookaround_launch("")
+
+
+@pytest.mark.integration
+def test_launch_lookaround_samdev_dev(samdev):
     lookaround_launch("--devserver")
 
 
@@ -507,6 +512,7 @@ def xx_test_jobsub_q_repetitions(samdev):
     assert count == 5
 
 
+@pytest.mark.smoke
 @pytest.mark.integration
 def test_wait_for_jobs():
     """Not really a test, but we have to wait for jobs to complete..."""
@@ -553,6 +559,7 @@ def test_wait_for_jobs():
     assert True
 
 
+@pytest.mark.smoke
 @pytest.mark.integration
 def test_fetch_output():
     for jid in joblist:
@@ -565,6 +572,7 @@ def test_fetch_output():
         )
 
 
+@pytest.mark.smoke
 @pytest.mark.integration
 def test_check_job_output():
     res = True


### PR DESCRIPTION
Computing list of environment variables in utils.py, list now includes LC_CYTPE, but is also checked against -e/--environment variables.   Added a shorter "smoke" test category to the test suite that submits one job and checks it.