### PR TITLE
Refactor submit

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -204,7 +204,7 @@ def main():
     elif args.maxConcurrent:
         jobsub_submit_maxconcurrent(varg, schedd_name)
     else:
-        jobsub_submit_simple(varg)
+        jobsub_submit_simple(varg, schedd_name)
 
     if args.verbose:
         # remind folks where transferred data goes.

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -44,7 +44,7 @@ PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(PREFIX, "lib"))
 from packages import pkg_find
 
-pkg_find("jinja")
+pkg_find("jinja")  # type: ignore
 import jinja2 as jinja
 
 #
@@ -66,141 +66,19 @@ from version import print_version, print_support_email
 from fake_ifdh import mkdir_p, cp
 import pool
 import skip_checks
-
-
-def get_basefiles(dlist: List[str]) -> List[str]:
-    """get basename of files in directory"""
-    res = []
-    for d in dlist:
-        flist = glob.glob(f"{d}/*")
-        for f in flist:
-            res.append(os.path.basename(f))
-    return res
-
-
-def render_files(
-    srcdir: str, values: Dict[str, Any], dest: str, dlist: Union[None, List[str]] = None
-):
-    """use jinja to render the templates from srcdir into the dest directory
-    using values dict for substitutions
-    """
-    if values.get("verbose", 0) > 0:
-        print(f"trying to render files from {srcdir}\n")
-
-    if dlist is None:
-        dlist = [srcdir]
-    values["transfer_files"] = get_basefiles(dlist)
-
-    jinja_env = jinja.Environment(
-        loader=jinja.FileSystemLoader(srcdir), undefined=jinja.StrictUndefined
-    )
-    jinja_env.filters["basename"] = os.path.basename
-    flist = glob.glob(f"{srcdir}/*")
-
-    # add destination dir to values for template
-    values["cwd"] = dest
-
-    for f in flist:
-        if values["verbose"] > 0:
-            print(f"rendering: {f}")
-        bf = os.path.basename(f)
-        rendered_file = os.path.join(dest, bf)
-        try:
-            with open(rendered_file, "w", encoding="UTF-8") as of:
-                of.write(jinja_env.get_template(bf).render(**values))
-        except jinja.exceptions.UndefinedError as e:
-            err = f"""Cannot render template file {f} due to undefined template variables.
-{e}
-Please open a ticket to the Service Desk and include this error message
-in its entirety.
-"""
-            print(err)
-            raise
-        if rendered_file.endswith(".sh"):
-            os.chmod(rendered_file, 0o755)
-        else:
-            if values.get("verbose", 0) > 0:
-                print(f"Created file {rendered_file}")
-
-
-def do_dataset_defaults(varg: Dict[str, Any]) -> None:
-    """
-    make sure to pass appropriate SAM_* environment variables if we
-    are doing datasets.  Pick a SAM_PROJECT name if we don't have one.
-    """
-    have_project = False
-    have_dataset = False
-    have_station = False
-    have_user = False
-    have_group = False
-    experiment = varg["group"]
-
-    if varg["project_name"]:
-        varg["environment"].append(f"SAM_PROJECT={varg['project_name']}")
-        varg["environment"].append(f"SAM_PROJECT_NAME={varg['project_name']}")
-
-    for e in varg["environment"]:
-        pos = e.find("=")
-        if e[:pos] == "SAM_PROJECT":
-            have_project = True
-        if e[:pos] == "SAM_DATASET":
-            have_dataset = True
-        if e[:pos] == "SAM_STATION":
-            have_station = True
-        if e[:pos] == "SAM_USER":
-            have_user = True
-        if e[:pos] == "SAM_GROUP":
-            have_group = True
-        if e[:pos] == "SAM_EXPERIMENT":
-            experiment = e[pos + 1 :]
-
-    if not have_project:
-        # if not, grab from the environment, or use dataset_$USER_$uuid
-        projname = os.environ.get(
-            "SAM_PROJECT",
-            f'{varg["dataset_definition"]}_{os.environ.get("USER", "")}_{varg["uuid"]}',
-        )
-        varg["environment"].append(f"SAM_PROJECT={projname}")
-        varg["environment"].append(f"SAM_PROJECT_NAME={projname}")
-    if not have_dataset:
-        varg["environment"].append(f"SAM_DATASET={varg['dataset_definition']}")
-    if not have_station:
-        varg["environment"].append(f"SAM_STATION={experiment}")
-    if not have_user:
-        varg["environment"].append(f"SAM_USER={os.environ['USER']}")
-    if not have_group:
-        varg["environment"].append(f"SAM_GROUP={experiment}")
-
-
-def transfer_sandbox(src_dir, dest_url):
-    """Transfer files from src_dir to sandbox with fake_ifdh (gfal-copy).
-    Nothing failing here is considered fatal, since it doesn't affect the job
-    itself, just log availability.
-
-    """
-    print("Transferring files to web sandbox...")
-    try:
-        mkdir_p(dest_url)
-    except Exception as e:
-        print(
-            f"warning: error creating sandbox, web logs will not be available for this submission: {e}"
-        )
-        return
-    for f in os.listdir(src_dir):
-        try:
-            cp(os.path.join(src_dir, f), os.path.join(dest_url, f))
-        except Exception as e:
-            print(
-                f"warning: error copying {f} to sandbox, will not be available through web logs: {e}"
-            )
-
+from submit_support import (
+    get_basefiles,
+    render_files,
+    do_dataset_defaults,
+    transfer_sandbox,
+    get_env_list,
+    jobsub_submit_dag,
+    jobsub_submit_dataset_definition,
+    jobsub_submit_maxconcurrent,
+    jobsub_submit_simple,
+)
 
 verbose = 0
-
-
-def get_env_list(name: str) -> List[str]:
-    """get a split comma separated list of strings from an environment variable"""
-    return [x for x in os.environ.get(name, "").split(",") if x]
 
 
 def main():
@@ -318,70 +196,15 @@ def main():
     varg["oauth_handle"] = m.hexdigest()[:10]
 
     set_extras_n_fix_units(varg, schedd_name, proxy, token)
-    submitdir = varg["outdir"]
-
-    # if proxy:
-    #    proxy_dest=os.path.join(submitdir,os.path.basename(proxy))
-    #    shutil.copyfile(proxy, proxy_dest)
-    #    varg["proxy"] = proxy_dest
-    # if token:
-    #    token_dest=os.path.join(submitdir,os.path.basename(token))
-    #    shutil.copyfile(token, token_dest)
-    #    varg["token"] = token_dest
 
     if args.dag:
-        varg["is_dag"] = True
-        d1 = os.path.join(PREFIX, "templates", "simple")
-        d2 = os.path.join(PREFIX, "templates", "dag")
-        parse_dagnabbit(d1, varg, submitdir, schedd_name, varg["verbose"] > 1)
-        render_files(d2, varg, submitdir, dlist=[d2, submitdir])
-        if not varg.get("no_submit", False):
-            if varg["outurl"]:
-                transfer_sandbox(submitdir, varg["outurl"])
-            os.chdir(varg["submitdir"])
-            submit_dag(os.path.join(submitdir, "dag.dag"), varg, schedd_name)
+        jobsub_submit_dag(varg, schedd_name)
     elif args.dataset_definition:
-        varg["is_dag"] = True
-        do_dataset_defaults(varg)
-        d1 = os.path.join(PREFIX, "templates", "dataset_dag")
-        d2 = f"{PREFIX}/templates/simple"
-        # so we render the simple area (d2) with -N 1 because
-        # we are making a loop of 1..N in th dataset_dag area
-        # otherwise we get N submissions of N jobs -> N^2 jobs...
-        saveN = varg["N"]
-        varg["N"] = "1"
-        render_files(d2, varg, submitdir, dlist=[d1, d2])
-        varg["N"] = saveN
-        render_files(d1, varg, submitdir, dlist=[d1, d2, submitdir])
-        if not varg.get("no_submit", False):
-            if varg["outurl"]:
-                transfer_sandbox(submitdir, varg["outurl"])
-            os.chdir(varg["submitdir"])
-            submit_dag(os.path.join(submitdir, "dataset.dag"), varg, schedd_name)
+        jobsub_submit_dataset_definition(varg, schedd_name)
     elif args.maxConcurrent:
-        varg["is_dag"] = True
-        d1 = os.path.join(PREFIX, "templates", "maxconcurrent_dag")
-        d2 = os.path.join(PREFIX, "templates", "simple")
-        # see above bit about -N 1
-        saveN = varg["N"]
-        varg["N"] = "1"
-        render_files(d2, varg, submitdir, dlist=[d1, d2])
-        varg["N"] = saveN
-        render_files(d1, varg, submitdir, dlist=[d1, d2, submitdir])
-        if not varg.get("no_submit", False):
-            if varg["outurl"]:
-                transfer_sandbox(submitdir, varg["outurl"])
-            os.chdir(varg["submitdir"])
-            submit_dag(os.path.join(submitdir, "maxconcurrent.dag"), varg, schedd_name)
+        jobsub_submit_maxconcurrent(varg, schedd_name)
     else:
-        varg["is_dag"] = False
-        d = f"{PREFIX}/templates/simple"
-        render_files(d, varg, submitdir)
-        if not varg.get("no_submit", False):
-            os.chdir(varg["submitdir"])
-            if varg["outurl"]:
-                transfer_sandbox(submitdir, varg["outurl"])
-            submit(os.path.join(submitdir, "simple.cmd"), varg, schedd_name)
+        jobsub_submit_simple(varg)
 
     if args.verbose:
         # remind folks where transferred data goes.

--- a/lib/submit_support.py
+++ b/lib/submit_support.py
@@ -1,0 +1,225 @@
+# pylint: disable=wrong-import-position,wrong-import-order,import-error
+import argparse
+import glob
+import hashlib
+import os
+import os.path
+import sys
+from typing import Union, List, Dict, Any
+
+import jinja2 as jinja  # type: ignore
+from get_parser import get_parser
+from condor import get_schedd, submit, submit_dag
+from dagnabbit import parse_dagnabbit
+from tarfiles import do_tarballs
+from utils import (
+    set_extras_n_fix_units,
+    cleanup,
+    backslash_escape_layer,
+    sanitize_lines,
+)
+from creds import get_creds
+from token_mods import get_job_scopes, use_token_copy
+from version import print_version, print_support_email
+from fake_ifdh import mkdir_p, cp
+import pool
+import skip_checks
+
+PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def get_basefiles(dlist: List[str]) -> List[str]:
+    """get basename of files in directory"""
+    res = []
+    for d in dlist:
+        flist = glob.glob(f"{d}/*")
+        for f in flist:
+            res.append(os.path.basename(f))
+    return res
+
+
+def render_files(
+    srcdir: str, values: Dict[str, Any], dest: str, dlist: Union[None, List[str]] = None
+) -> None:
+    """use jinja to render the templates from srcdir into the dest directory
+    using values dict for substitutions
+    """
+    if values.get("verbose", 0) > 0:
+        print(f"trying to render files from {srcdir}\n")
+
+    if dlist is None:
+        dlist = [srcdir]
+    values["transfer_files"] = get_basefiles(dlist)
+
+    jinja_env = jinja.Environment(
+        loader=jinja.FileSystemLoader(srcdir), undefined=jinja.StrictUndefined
+    )
+    jinja_env.filters["basename"] = os.path.basename
+    flist = glob.glob(f"{srcdir}/*")
+
+    # add destination dir to values for template
+    values["cwd"] = dest
+
+    for f in flist:
+        if values["verbose"] > 0:
+            print(f"rendering: {f}")
+        bf = os.path.basename(f)
+        rendered_file = os.path.join(dest, bf)
+        try:
+            with open(rendered_file, "w", encoding="UTF-8") as of:
+                of.write(jinja_env.get_template(bf).render(**values))
+        except jinja.exceptions.UndefinedError as e:
+            err = f"""Cannot render template file {f} due to undefined template variables.
+{e}
+Please open a ticket to the Service Desk and include this error message
+in its entirety.
+"""
+            print(err)
+            raise
+        if rendered_file.endswith(".sh"):
+            os.chmod(rendered_file, 0o755)
+        else:
+            if values.get("verbose", 0) > 0:
+                print(f"Created file {rendered_file}")
+
+
+def do_dataset_defaults(varg: Dict[str, Any]) -> None:
+    """
+    make sure to pass appropriate SAM_* environment variables if we
+    are doing datasets.  Pick a SAM_PROJECT name if we don't have one.
+    """
+    have_project = False
+    have_dataset = False
+    have_station = False
+    have_user = False
+    have_group = False
+    experiment = varg["group"]
+
+    if varg["project_name"]:
+        varg["environment"].append(f"SAM_PROJECT={varg['project_name']}")
+        varg["environment"].append(f"SAM_PROJECT_NAME={varg['project_name']}")
+
+    for e in varg["environment"]:
+        pos = e.find("=")
+        if e[:pos] == "SAM_PROJECT":
+            have_project = True
+        if e[:pos] == "SAM_DATASET":
+            have_dataset = True
+        if e[:pos] == "SAM_STATION":
+            have_station = True
+        if e[:pos] == "SAM_USER":
+            have_user = True
+        if e[:pos] == "SAM_GROUP":
+            have_group = True
+        if e[:pos] == "SAM_EXPERIMENT":
+            experiment = e[pos + 1 :]
+
+    if not have_project:
+        # if not, grab from the environment, or use dataset_$USER_$uuid
+        projname = os.environ.get(
+            "SAM_PROJECT",
+            f'{varg["dataset_definition"]}_{os.environ.get("USER", "")}_{varg["uuid"]}',
+        )
+        varg["environment"].append(f"SAM_PROJECT={projname}")
+        varg["environment"].append(f"SAM_PROJECT_NAME={projname}")
+    if not have_dataset:
+        varg["environment"].append(f"SAM_DATASET={varg['dataset_definition']}")
+    if not have_station:
+        varg["environment"].append(f"SAM_STATION={experiment}")
+    if not have_user:
+        varg["environment"].append(f"SAM_USER={os.environ['USER']}")
+    if not have_group:
+        varg["environment"].append(f"SAM_GROUP={experiment}")
+
+
+def transfer_sandbox(src_dir: str, dest_url: str) -> None:
+    """Transfer files from src_dir to sandbox with fake_ifdh (gfal-copy).
+    Nothing failing here is considered fatal, since it doesn't affect the job
+    itself, just log availability.
+
+    """
+    print("Transferring files to web sandbox...")
+    try:
+        mkdir_p(dest_url)
+    except Exception as e:
+        print(
+            f"warning: error creating sandbox, web logs will not be available for this submission: {e}"
+        )
+        return
+    for f in os.listdir(src_dir):
+        try:
+            cp(os.path.join(src_dir, f), os.path.join(dest_url, f))
+        except Exception as e:
+            print(
+                f"warning: error copying {f} to sandbox, will not be available through web logs: {e}"
+            )
+
+
+def get_env_list(name: str) -> List[str]:
+    """get a split comma separated list of strings from an environment variable"""
+    return [x for x in os.environ.get(name, "").split(",") if x]
+
+
+def jobsub_submit_dag(varg: Dict[str, Any], schedd_name: str) -> None:
+    submitdir = varg["outdir"]
+    varg["is_dag"] = True
+    d1 = os.path.join(PREFIX, "templates", "simple")
+    d2 = os.path.join(PREFIX, "templates", "dag")
+    parse_dagnabbit(d1, varg, submitdir, schedd_name, varg["verbose"] > 1)
+    render_files(d2, varg, submitdir, dlist=[d2, submitdir])
+    if not varg.get("no_submit", False):
+        if varg["outurl"]:
+            transfer_sandbox(submitdir, varg["outurl"])
+        os.chdir(varg["submitdir"])
+        submit_dag(os.path.join(submitdir, "dag.dag"), varg, schedd_name)
+
+
+def jobsub_submit_dataset_definition(varg: Dict[str, Any], schedd_name: str) -> None:
+    submitdir = varg["outdir"]
+    varg["is_dag"] = True
+    do_dataset_defaults(varg)
+    d1 = os.path.join(PREFIX, "templates", "dataset_dag")
+    d2 = f"{PREFIX}/templates/simple"
+    # so we render the simple area (d2) with -N 1 because
+    # we are making a loop of 1..N in th dataset_dag area
+    # otherwise we get N submissions of N jobs -> N^2 jobs...
+    saveN = varg["N"]
+    varg["N"] = "1"
+    render_files(d2, varg, submitdir, dlist=[d1, d2])
+    varg["N"] = saveN
+    render_files(d1, varg, submitdir, dlist=[d1, d2, submitdir])
+    if not varg.get("no_submit", False):
+        if varg["outurl"]:
+            transfer_sandbox(submitdir, varg["outurl"])
+        os.chdir(varg["submitdir"])
+        submit_dag(os.path.join(submitdir, "dataset.dag"), varg, schedd_name)
+
+
+def jobsub_submit_maxconcurrent(varg: Dict[str, Any], schedd_name: str) -> None:
+    submitdir = varg["outdir"]
+    varg["is_dag"] = True
+    d1 = os.path.join(PREFIX, "templates", "maxconcurrent_dag")
+    d2 = os.path.join(PREFIX, "templates", "simple")
+    # see above bit about -N 1
+    saveN = varg["N"]
+    varg["N"] = "1"
+    render_files(d2, varg, submitdir, dlist=[d1, d2])
+    varg["N"] = saveN
+    render_files(d1, varg, submitdir, dlist=[d1, d2, submitdir])
+    if not varg.get("no_submit", False):
+        if varg["outurl"]:
+            transfer_sandbox(submitdir, varg["outurl"])
+        os.chdir(varg["submitdir"])
+        submit_dag(os.path.join(submitdir, "maxconcurrent.dag"), varg, schedd_name)
+
+
+def jobsub_submit_simple(varg: Dict[str, Any], schedd_name: str) -> None:
+    submitdir = varg["outdir"]
+    varg["is_dag"] = False
+    d = f"{PREFIX}/templates/simple"
+    render_files(d, varg, submitdir)
+    if not varg.get("no_submit", False):
+        os.chdir(varg["submitdir"])
+        if varg["outurl"]:
+            transfer_sandbox(submitdir, varg["outurl"])
+        submit(os.path.join(submitdir, "simple.cmd"), varg, schedd_name)

--- a/lib/submit_support.py
+++ b/lib/submit_support.py
@@ -25,6 +25,8 @@ from fake_ifdh import mkdir_p, cp
 import pool
 import skip_checks
 
+""" Code factored out of jobsub_submit """
+
 PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -161,6 +163,7 @@ def get_env_list(name: str) -> List[str]:
 
 
 def jobsub_submit_dag(varg: Dict[str, Any], schedd_name: str) -> None:
+    """do a submission to schedd with --dag using the dagnabbit parser"""
     submitdir = varg["outdir"]
     varg["is_dag"] = True
     d1 = os.path.join(PREFIX, "templates", "simple")
@@ -175,6 +178,7 @@ def jobsub_submit_dag(varg: Dict[str, Any], schedd_name: str) -> None:
 
 
 def jobsub_submit_dataset_definition(varg: Dict[str, Any], schedd_name: str) -> None:
+    """do a submission to schedd with --dataset-definition  and a 3-stage dag"""
     submitdir = varg["outdir"]
     varg["is_dag"] = True
     do_dataset_defaults(varg)
@@ -196,6 +200,7 @@ def jobsub_submit_dataset_definition(varg: Dict[str, Any], schedd_name: str) -> 
 
 
 def jobsub_submit_maxconcurrent(varg: Dict[str, Any], schedd_name: str) -> None:
+    """do a --maxConcurrent dag job submission to schedd"""
     submitdir = varg["outdir"]
     varg["is_dag"] = True
     d1 = os.path.join(PREFIX, "templates", "maxconcurrent_dag")
@@ -214,6 +219,7 @@ def jobsub_submit_maxconcurrent(varg: Dict[str, Any], schedd_name: str) -> None:
 
 
 def jobsub_submit_simple(varg: Dict[str, Any], schedd_name: str) -> None:
+    """a  simple (non-DAG) submission"""
     submitdir = varg["outdir"]
     varg["is_dag"] = False
     d = f"{PREFIX}/templates/simple"

--- a/tests/test_jobsub_submit_unit.py
+++ b/tests/test_jobsub_submit_unit.py
@@ -23,17 +23,7 @@ import utils
 
 from test_unit import TestUnit
 
-try:
-    os.unlink("jobsub_submit.py")
-except:
-    pass
-if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
-    if not os.path.exists("jobsub_submit.py"):
-        os.symlink("/opt/jobsub_lite/bin/jobsub_submit", "jobsub_submit.py")
-else:
-    if not os.path.exists("jobsub_submit.py"):
-        os.symlink("../bin/jobsub_submit", "jobsub_submit.py")
-import jobsub_submit
+import submit_support
 
 
 class TestJobsubSubmitUnit:
@@ -48,7 +38,7 @@ class TestJobsubSubmitUnit:
         """test the get_basefiles routine on our source directory,
         we should be in it"""
         dlist = [os.path.dirname(__file__)]
-        fl = jobsub_submit.get_basefiles(dlist)
+        fl = submit_support.get_basefiles(dlist)
         assert os.path.basename(__file__) in fl
 
     @pytest.mark.unit
@@ -66,7 +56,7 @@ class TestJobsubSubmitUnit:
         args = {**TestUnit.test_vargs, **TestUnit.test_extra_template_args}
         args["outdir"] = dest
         args["proxy"] = "/fake/proxy/path"
-        jobsub_submit.render_files(srcdir, args, dest)
+        submit_support.render_files(srcdir, args, dest)
         assert os.path.exists("%s/dagbegin.cmd" % dest)
 
     @pytest.mark.unit
@@ -86,7 +76,7 @@ class TestJobsubSubmitUnit:
         args["proxy"] = "/fake/proxy/path"
         args["dd_percentage"] = 33
         args["dd_extra_dataset"] = ["dataset1", "dataset2"]
-        jobsub_submit.render_files(srcdir, args, dest)
+        submit_support.render_files(srcdir, args, dest)
         found_percent = False
         found_extra_dataset = False
         with open("%s/sambegin.sh" % dest, "r") as fin:
@@ -112,7 +102,7 @@ class TestJobsubSubmitUnit:
             os.mkdir(dest)
         args = {**TestUnit.test_vargs, **TestUnit.test_extra_template_args}
         with pytest.raises(exceptions.UndefinedError, match="is undefined"):
-            jobsub_submit.render_files(srcdir, args, dest)
+            submit_support.render_files(srcdir, args, dest)
 
     @pytest.mark.unit
     def test_do_dataset_defaults_1(self):
@@ -120,6 +110,6 @@ class TestJobsubSubmitUnit:
         varg = TestUnit.test_vargs.copy()
         varg["dataset_definition"] = "mwmtest"
         utils.set_extras_n_fix_units(varg, TestUnit.test_schedd, "", "")
-        jobsub_submit.do_dataset_defaults(varg)
+        submit_support.do_dataset_defaults(varg)
         for var in ["PROJECT", "DATASET", "USER", "GROUP", "STATION"]:
             assert repr(varg["environment"]).find("SAM_%s" % var) > 0


### PR DESCRIPTION
Implementation of #451.    Created a new lib/submit_support.py with code that was already subroutines in jobsub_submit, and some more code split out to make the mainline more manageable.   Boundary between this code and utils.py  routines is unclear, should maybe have just made them utils1.py and utils2.py or something.

Note that this pull request attempts to make no changes to actual code; just *moves* it to another file and 
adds a few `def function_name(args, schedd_name): ` lines.   So wherever you see a block of code replaced by a subroutine call, you should later find that exact code in the body of that subroutine.

This probably leaves jobsub_submit with some imports it doesn't need any more, if folks are looking for more small improvements.