### PR TITLE
Make obtaining proxy optional in job submission

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -41,7 +41,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 from condor import get_schedd, submit
-from creds import get_creds
+from creds import get_creds, print_cred_paths_from_credset
 import get_parser
 
 # pylint: disable-next=no-member
@@ -123,10 +123,9 @@ def main():
         )
         return
 
-    proxy, token = get_creds(vars(args))
+    cred_set = get_creds(vars(args))
     if args.verbose:
-        print(f"proxy is : {proxy}")
-        print(f"token is : {token}")
+        print_cred_paths_from_credset(cred_set)
 
     #   SUBMIT
 

--- a/bin/condor_submit_dag
+++ b/bin/condor_submit_dag
@@ -37,7 +37,7 @@ sys.path.append(os.path.join(PREFIX, "lib"))
 # import our local parts
 #
 from condor import get_schedd, submit_dag
-from creds import get_creds
+from creds import get_creds, print_cred_paths_from_credset
 import get_parser
 
 
@@ -66,11 +66,9 @@ def main():
     if arglist.verbose:
         cmd_args.append("-debug")
 
-    proxy, token = get_creds(arglist)
-
-    # put in environment for condor libs to use
-    os.environ["X509_USER_PROXY"] = proxy
-    os.environ["BEARER_TOKEN_FILE"] = token
+    cred_set = get_creds(vars(arglist))
+    if arglist.verbose:
+        print_cred_paths_from_credset(cred_set)
 
     if os.environ.get("GROUP", None) is None:
         raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -35,7 +35,7 @@ if os.environ.get("LD_LIBRARY_PATH", ""):
 PREFIX = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(PREFIX, "lib"))
 
-import fake_ifdh
+import creds
 import get_parser
 import condor
 from version import print_version, print_support_email
@@ -160,9 +160,7 @@ def main() -> None:
         execargs.append(i)
 
     # also make sure we have suitable credentials...
-    role = fake_ifdh.getRole(arglist.role)
-    os.environ["X509_USER_PROXY"] = fake_ifdh.getProxy(role)
-    os.environ["BEARER_TOKEN_FILE"] = fake_ifdh.getToken(role)
+    _ = creds.get_creds(arglist)
 
     # and find the wrapped command name
     cmd = os.path.basename(sys.argv[0])

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -160,7 +160,7 @@ def main() -> None:
         execargs.append(i)
 
     # also make sure we have suitable credentials...
-    _ = creds.get_creds(arglist)
+    _ = creds.get_creds(vars(arglist))
 
     # and find the wrapped command name
     cmd = os.path.basename(sys.argv[0])

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -241,6 +241,12 @@ def main():
     if args.support_email:
         print_support_email()
 
+    # jobsub_fetchlog only supports tokens
+    if "tokens" not in args.auth_methods:
+        raise SystemExit(
+            "jobsub_fetchlog only supports token authentication.  Please either omit the --auth-methods flag or make sure tokens is included in the value of that flag"
+        )
+
     if not args.jobid and not args.job_id:
         raise SystemExit("jobid is required.")
 

--- a/bin/jobsub_fetchlog
+++ b/bin/jobsub_fetchlog
@@ -260,11 +260,9 @@ def main():
             "%s needs -G group or $GROUP in the environment." % sys.argv[0]
         )
 
-    proxy, token = creds.get_creds(vars(args))
-
+    cred_set = creds.get_creds(vars(args))
     if args.verbose:
-        print("proxy is : %s" % proxy)
-        print("token is : %s" % token)
+        creds.print_cred_paths_from_credset(cred_set)
 
     fetcher = fetch_from_condor if args.condor else fetch_from_landscape
     fetcher(args.jobid, args.destdir, args.archive_format, args.partial)

--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -60,7 +60,7 @@ from utils import (
     backslash_escape_layer,
     sanitize_lines,
 )
-from creds import get_creds
+from creds import get_creds, print_cred_paths_from_credset
 from token_mods import get_job_scopes, use_token_copy
 from version import print_version, print_support_email
 from fake_ifdh import mkdir_p, cp
@@ -159,11 +159,9 @@ def main():
 
     varg = vars(args)
 
-    proxy, token = get_creds(varg)
-
+    cred_set = get_creds(varg)
     if args.verbose:
-        print(f"proxy is : {proxy}")
-        print(f"token is : {token}")
+        print_cred_paths_from_credset(cred_set)
 
     if args.verbose:
         sys.stderr.write(f"varg: {repr(varg)}\n")
@@ -187,15 +185,16 @@ def main():
     # token filename the conor_vault_credmon will only refresh it once for both (or all
     # three, etc.) submissions, and push that token to all the jobs with that same handle.
     #
-    token = use_token_copy(token)
-    varg["job_scope"] = " ".join(
-        get_job_scopes(token, args.need_storage_modify, args.need_scope)
-    )
-    m = hashlib.sha256()
-    m.update(varg["job_scope"].encode())
-    varg["oauth_handle"] = m.hexdigest()[:10]
+    if cred_set.token:
+        cred_set.token = use_token_copy(cred_set.token)
+        varg["job_scope"] = " ".join(
+            get_job_scopes(cred_set.token, args.need_storage_modify, args.need_scope)
+        )
+        m = hashlib.sha256()
+        m.update(varg["job_scope"].encode())
+        varg["oauth_handle"] = m.hexdigest()[:10]
 
-    set_extras_n_fix_units(varg, schedd_name, proxy, token)
+    set_extras_n_fix_units(varg, schedd_name, cred_set.proxy, cred_set.token)
 
     if args.dag:
         jobsub_submit_dag(varg, schedd_name)

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -273,7 +273,7 @@ def submit(
 
     qargs = " ".join([f"'{x}'" for x in cmd_args])
     cmd = f"/usr/bin/condor_submit -pool {COLLECTOR_HOST} {schedd_args} {qargs}"
-    if vargs["token"] is not None:
+    if vargs.get("token", None) is not None:
         cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
     cmd = f"_condor_CREDD_HOST={schedd_name} {cmd}"
     #
@@ -375,7 +375,7 @@ def submit_dag(
             f' "use_oauth_services = {vargs["group"]}" -no_submit {f} {qargs}'
         )
 
-        if vargs["token"] is not None:
+        if vargs.get("token", None) is not None:
             cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
         if vargs.get("verbose", 0) > 0:
             print(f"Running: {cmd}")

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -375,7 +375,8 @@ def submit_dag(
             f' "use_oauth_services = {vargs["group"]}" -no_submit {f} {qargs}'
         )
 
-        cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
+        if vargs["token"] is not None:
+            cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
         if vargs.get("verbose", 0) > 0:
             print(f"Running: {cmd}")
 

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -273,7 +273,8 @@ def submit(
 
     qargs = " ".join([f"'{x}'" for x in cmd_args])
     cmd = f"/usr/bin/condor_submit -pool {COLLECTOR_HOST} {schedd_args} {qargs}"
-    cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
+    if vargs["token"] is not None:
+        cmd = f"BEARER_TOKEN_FILE={os.environ['BEARER_TOKEN_FILE']} {cmd}"
     cmd = f"_condor_CREDD_HOST={schedd_name} {cmd}"
     #
     # set up to use our custom condor_vault_storer until we get

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -72,6 +72,9 @@ def get_creds(args: Dict[str, Any] = {}) -> CredentialSet:
             f"in requested authorization methods {auth_methods}"
         )
 
+    if args.get("verbose", 0) > 0:
+        print(f"Requested auth methods are: {auth_methods}")
+
     creds_to_return: Dict[str, Optional[str]] = {
         cred_type: None for cred_type in SUPPORTED_AUTH_METHODS
     }

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -14,26 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ credential related routines """
+import argparse
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 import fake_ifdh
 
+
+DEFAULT_AUTH_METHOD = "token"
+SUPPORTED_AUTH_METHODS = ["token", "proxy"]
+
 # pylint: disable-next=dangerous-default-value
-def get_creds(args: Dict[str, Any] = {}) -> Tuple[str, str]:
+def get_creds(args: Dict[str, Any] = {}) -> Tuple[str, ...]:
     """get credentials -- Note this does not currently push to
     myproxy, nor does it yet deal with tokens, but those should
     be done here as needed.
     """
-
     role = fake_ifdh.getRole(args.get("role", None))
     args["role"] = role
-    p = fake_ifdh.getProxy(role, args.get("verbose", 0), args.get("force_proxy", False))
-    t = fake_ifdh.getToken(role, args.get("verbose", 0))
 
-    p = p.strip()
-    t = t.strip()
-    os.environ["X509_USER_PROXY"] = p
-    os.environ["BEARER_TOKEN_FILE"] = t
+    auth_methods = args.get("auth_methods", SUPPORTED_AUTH_METHODS)
 
-    return p, t
+    obtained_creds = []
+    # TODO Enum to map from proxy to getProxy, token to getToken?
+    # TODO Callers should support either of token or proxy or both being returned
+    if "token" in auth_methods:
+        t = fake_ifdh.getToken(role, args.get("verbose", 0))
+        t = t.strip()
+        obtained_creds.append(t)
+        os.environ["BEARER_TOKEN_FILE"] = t
+    if "proxy" in auth_methods:
+        p = fake_ifdh.getProxy(
+            role, args.get("verbose", 0), args.get("force_proxy", False)
+        )
+        p = p.strip()
+        obtained_creds.append(p)
+        os.environ["X509_USER_PROXY"] = p
+
+    return tuple(obtained_creds)
+
+
+class CheckIfValidAuthMethod(argparse.Action):
+    """Action to check if the caller has requested a valid auth method"""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Union[None, str] = None,
+    ) -> None:
+        check_values = [value.strip() for value in values.split()]
+        for value in check_values:
+            if value not in SUPPORTED_AUTH_METHODS:
+                raise TypeError(
+                    f"Invalid auth method {value}.  Supported auth methods are {SUPPORTED_AUTH_METHODS}"
+                )
+        setattr(namespace, self.dest, ",".join(check_values))

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -99,6 +99,9 @@ class CheckIfValidAuthMethod(argparse.Action):
         option_string: Union[None, str] = None,
     ) -> None:
         check_values = [value.strip() for value in values.split()]
+        if len(check_values) == 0:
+            setattr(namespace, self.dest, ",".join(SUPPORTED_AUTH_METHODS))
+            return
         for value in check_values:
             if value not in SUPPORTED_AUTH_METHODS:
                 raise TypeError(

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -44,7 +44,7 @@ class CredentialSet:
         for cred_type, cred_path in vars(self).items():
             if not cred_path:
                 continue
-            self_key = f"{cred_type.upper}_ENV"
+            self_key = f"{cred_type.upper()}_ENV"
             environ_key = getattr(self, self_key, None)
             if environ_key:
                 os.environ[environ_key] = cred_path

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -67,7 +67,6 @@ def get_creds(args: Dict[str, Any] = {}) -> CredentialSet:
     creds_to_return: Dict[str, Optional[str]] = {
         cred_type: None for cred_type in SUPPORTED_AUTH_METHODS
     }
-    # TODO Templates should also support token or proxy not existing
     if "token" in auth_methods:
         t = fake_ifdh.getToken(role, args.get("verbose", 0))
         t = t.strip()
@@ -98,7 +97,10 @@ class CheckIfValidAuthMethod(argparse.Action):
         values: Any,
         option_string: Union[None, str] = None,
     ) -> None:
-        check_values = [value.strip() for value in values.split()]
+        check_values = [value.strip() for value in values.split(",")]
+        check_values = list(
+            filter(lambda val: val != "", check_values)
+        )  # Clear out empty string
         if len(check_values) == 0:
             setattr(namespace, self.dest, ",".join(SUPPORTED_AUTH_METHODS))
             return

--- a/lib/dagnabbit.py
+++ b/lib/dagnabbit.py
@@ -43,7 +43,7 @@ def parse_dagnabbit(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     jinja_env = jinja.Environment(loader=jinja.FileSystemLoader(srcdir))
     jinja_env.filters["basename"] = os.path.basename
-    proxy, token = creds.get_creds(values)
+    cred_set = creds.get_creds(values)
     prev_jobsub_line = "xxx"
     prev_jobsub_count = 0
     count = 0
@@ -207,7 +207,9 @@ def parse_dagnabbit(
                         else:
                             thesevalues[k] = update_with[k]
 
-                    set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
+                    set_extras_n_fix_units(
+                        thesevalues, schedd_name, cred_set.proxy, cred_set.token
+                    )
                     thesevalues["script_name"] = f"{name}.sh"
                     thesevalues["cmd_name"] = f"{name}.cmd"
                     with open(
@@ -265,7 +267,9 @@ def parse_dagnabbit(
                 of.write(f"SCRIPT PRE {name} {prescript_base} {prescript_args}\n")
                 thesevalues["prescript"] = prescript
                 thesevalues.update(update_with)
-                set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
+                set_extras_n_fix_units(
+                    thesevalues, schedd_name, cred_set.proxy, cred_set.token
+                )
 
             elif line.startswith("postscript "):
                 if debug_comments:
@@ -292,7 +296,9 @@ def parse_dagnabbit(
                 of.write(f"SCRIPT POST {name} {postscript_base} {postscript_args}\n")
                 thesevalues["postscript"] = postscript
                 thesevalues.update(update_with)
-                set_extras_n_fix_units(thesevalues, schedd_name, proxy, token)
+                set_extras_n_fix_units(
+                    thesevalues, schedd_name, cred_set.proxy, cred_set.token
+                )
 
             elif not line.strip() or line.strip().startswith("#"):
                 # blank lines and comments are fine

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -133,7 +133,7 @@ class CheckIfValidAuthMethod(argparse.Action):
             return
 
         # Check that the requested auth methods include the required auth methods
-        required_auth_methods = set(REQUIRED_AUTH_METHODS.split(","))
+        required_auth_methods = set(REQUIRED_AUTH_METHODS)
         if len(required_auth_methods.intersection(set(check_values))) == 0:
             raise TypeError(
                 "The jobsub_lite infrastructure requires that the following "
@@ -175,7 +175,7 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
             "Authorization method to use for job management. "
             "Multiple values should be given in a comma-separated list, "
             'e.g. "token,proxy".'
-            f"Currently supported methods are {SUPPORTED_AUTH_METHODS}."
+            f"Currently supported methods are {SUPPORTED_AUTH_METHODS}. "
             f"The current infrastructure requires the following auth methods: {REQUIRED_AUTH_METHODS}"
         ),
         action=CheckIfValidAuthMethod,

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -22,6 +22,7 @@ import sys
 from typing import Union, Any, List
 
 import pool
+from creds import CheckIfValidAuthMethod, SUPPORTED_AUTH_METHODS
 from skip_checks import SupportedSkipChecks
 from utils import DEFAULT_USAGE_MODELS, DEFAULT_SINGULARITY_IMAGE
 from condor import get_schedd_names
@@ -130,6 +131,18 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
     if os.environ.get("JOBSUB_GROUP", ""):
         os.environ["GROUP"] = os.environ["JOBSUB_GROUP"]
 
+    group.add_argument(
+        "--auth-methods",
+        help=(
+            "Authorization method to use for job management. "
+            "Multiple values should be given in a comma-separated list, "
+            'e.g. "token,proxy".'
+            f"Currently supported methods are {SUPPORTED_AUTH_METHODS}"
+        ),
+        action=CheckIfValidAuthMethod,
+        required=False,
+        default=os.environ.get("JOBSUB_AUTH_METHODS", ",".join(SUPPORTED_AUTH_METHODS)),
+    )
     group.add_argument(
         "-G",
         "--group",

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -32,7 +32,7 @@ import requests  # type: ignore
 from requests.auth import AuthBase  # type: ignore
 
 import fake_ifdh
-from creds import get_creds
+from creds import get_creds, CredentialSet
 
 try:
     _NUM_RETRIES_ENV = os.getenv("JOBSUB_UPLOAD_NUM_RETRIES", "20")
@@ -296,7 +296,7 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
     location: Optional[str] = ""
     if args.use_dropbox == "cvmfs" or args.use_dropbox is None:
         digest = checksum_file(tfn)
-        proxy, token = get_creds(vars(args))
+        cred_set = get_creds(vars(args))
 
         if not args.group:
             raise ValueError("No --group specified!")
@@ -304,7 +304,7 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
         # cid looks something like dune/bf6a15b4238b72f82...(long hash)
         cid = f"{args.group}/{digest}"
 
-        publisher = TarfilePublisherHandler(cid, proxy, token, args.verbose)
+        publisher = TarfilePublisherHandler(cid, cred_set, args.verbose)
         location = publisher.cid_exists()
         if location is None:
             if args.verbose:
@@ -376,8 +376,8 @@ class TarfilePublisherHandler:
     Args:
         object (_type_): _description_
         cid (str): unique group/hash combination that RCDS uses to locate tarballs
-        proxy (str): Location of X509 Proxy file to authenticate to RCDS
-        token (str): Location of JWT/Sci-token to authenticate to RCDS
+        cred_set (CredentialSet): Paths to various supported credentials to authenticate to RCDS
+        verbose (int): Verbosity level
     """
 
     dropbox_server_string = os.getenv("JOBSUB_DROPBOX_SERVER_LIST", "")
@@ -388,20 +388,26 @@ class TarfilePublisherHandler:
     def __init__(
         self,
         cid: str,
-        proxy: Union[None, str] = None,
-        token: Union[None, str] = None,
+        cred_set: CredentialSet,
         verbose: int = 0,
     ):
         self.cid = cid
         self.cid_url = _quote(cid, safe="")  # Encode CID for passing to URL
-        self.proxy = proxy
-        self.token = token
         self.verbose = verbose
 
-        if token is not None:
-            print(f"Using bearer token located at {self.token} to authenticate to RCDS")
+        self.__auth_kwargs: Dict[str, Any]
+        if cred_set.token is not None:
+            print(
+                f"Using bearer token located at {cred_set.token} to authenticate to RCDS"
+            )
+            self.__auth_kwargs = {"auth": TokenAuth(cred_set.token)}
+        elif cred_set.proxy is not None:
+            print(
+                f"Using X509 proxy located at {cred_set.proxy} to authenticate to RCDS"
+            )
+            self.__auth_kwargs = {"cert": (cred_set.proxy, cred_set.proxy)}
         else:
-            print(f"Using X509 proxy located at {self.proxy} to authenticate to RCDS")
+            raise ValueError("No proxy or token provided to authenticate to RCDS.")
 
         self.pubapi_base_url_formatter_full = (
             f"https://{{dropbox_server}}/pubapi/{{endpoint}}"
@@ -487,9 +493,7 @@ class TarfilePublisherHandler:
         url = self.pubapi_cid_url_formatter.format(endpoint="update")
         if self.verbose:
             print(f"Calling URL {url}")
-        if self.token:
-            return requests.get(url, auth=TokenAuth(self.token))
-        return requests.get(url, cert=(self.proxy, self.proxy))
+        return requests.get(url, **self.__auth_kwargs)
 
     @cid_operation
     @pubapi_operation
@@ -508,9 +512,7 @@ class TarfilePublisherHandler:
             print(f"Calling URL {url}")
 
         with open(tarfilename, "rb") as tarfile:
-            if self.token:
-                return requests.post(url, auth=TokenAuth(self.token), data=tarfile)
-            return requests.post(url, cert=(self.proxy, self.proxy), data=tarfile)
+            return requests.post(url, data=tarfile, **self.__auth_kwargs)
 
     @cid_operation
     @pubapi_operation
@@ -524,9 +526,7 @@ class TarfilePublisherHandler:
         url = self.pubapi_cid_url_formatter.format(endpoint="exists")
         if self.verbose:
             print(f"Calling URL {url}")
-        if self.token:
-            return requests.get(url, auth=TokenAuth(self.token))
-        return requests.get(url, cert=(self.proxy, self.proxy))
+        return requests.get(url, **self.__auth_kwargs)
 
     def get_glob_path_for_cid(self) -> Optional[str]:
         """Return a glob path where a tarball given by self.cid can be found"""
@@ -539,9 +539,7 @@ class TarfilePublisherHandler:
     @pubapi_operation
     def _get_configured_pubapi_repos(self) -> requests.Response:
         url = self.pubapi_base_url_formatter.format(endpoint="config")
-        if self.token:
-            return requests.get(url, auth=TokenAuth(self.token))
-        return requests.get(url, cert=(self.proxy, self.proxy))
+        return requests.get(url, **self.__auth_kwargs)
 
     def __setup_dropbox_server_selector(self) -> Iterator[str]:
         """Return an infinite iterator of dropbox servers for client to upload tarball to"""

--- a/templates/dag/dag.dag.condor.sub
+++ b/templates/dag/dag.dag.condor.sub
@@ -24,7 +24,9 @@ environment	=  _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address
 +JobsubServerVersion="{{jobsub_version}}"
 +JobsubClientVersion="{{jobsub_version}}"
 +JobsubClientKerberosPrincipal="{{kerberos_principal}}"
+{% if proxy is defined and proxy %}
 x509userproxy = {{proxy}}
+{% endif %}
 delegate_job_GSI_credentials_lifetime = 0
 {%if skip_check is defined and skip_check%}
 +JobsubSkipChecks = "{{skip_check|join(",")}}"
@@ -47,12 +49,14 @@ notification = Always
 +JobsubOutputURL="{{outurl}}"
 +JobsubUUID="{{uuid}}"
 
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% else %}
 use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
+{% endif %}
 {% endif %}
 
 queue

--- a/templates/dataset_dag/dagbegin.cmd
+++ b/templates/dataset_dag/dagbegin.cmd
@@ -8,7 +8,7 @@ arguments          =
 output             = {{filebase}}.out
 error              = {{filebase}}.err
 log                = {{filebase}}.log
-environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP={{outdir}};BEARER_TOKEN_FILE=.condor_creds/{{group}}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
+environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP={{outdir}};{% if token is defined and token %}BEARER_TOKEN_FILE=.condor_creds/{{group}}.use{% endif %};CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
 rank                  = Mips / 2 + Memory
 notification  = Error
 +RUN_ON_HEADNODE= True
@@ -59,6 +59,7 @@ requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= Mach
 {% endif %}
 
 # Credentials
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}}  = " {{job_scope}} "
@@ -66,7 +67,8 @@ use_oauth_services = {{group}}_{{role | lower}}
 use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% endif %}
-{% if role is defined %}
+{% endif %}
+{% if role is defined and proxy is defined and proxy %}
 +x509userproxy = "{{proxy|basename}}"
 delegate_job_GSI_credentials_lifetime = 0
 {% endif %}

--- a/templates/dataset_dag/dagend.cmd
+++ b/templates/dataset_dag/dagend.cmd
@@ -8,7 +8,7 @@ arguments          =
 output             = {{filebase}}.out
 error              = {{filebase}}.err
 log                = {{filebase}}.log
-environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP={{outdir}};BEARER_TOKEN_FILE=.condor_creds/{{group}}.use;CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
+environment        = CLUSTER=$(Cluster);PROCESS=$(Process);CONDOR_TMP={{outdir}};{% if token is defined and token %}BEARER_TOKEN_FILE=.condor_creds/{{group}}.use{% endif %};CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
 rank                  = Mips / 2 + Memory
 notification  = Error
 +RUN_ON_HEADNODE= True
@@ -59,6 +59,7 @@ requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= Mach
 {% endif %}
 
 # Credentials
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}}  = " {{job_scope}} "
@@ -66,7 +67,8 @@ use_oauth_services = {{group}}_{{role | lower}}
 use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}}  = " {{job_scope}} "
 {% endif %}
-{% if role is defined %}
+{% endif %}
+{% if role is defined and proxy is defined and proxy %}
 +x509userproxy = "{{proxy|basename}}"
 delegate_job_GSI_credentials_lifetime = 0
 {% endif %}

--- a/templates/dataset_dag/dataset.dag.condor.sub
+++ b/templates/dataset_dag/dataset.dag.condor.sub
@@ -49,6 +49,7 @@ notification = Always
 +JobsubUUID="{{uuid}}"
 
 # Credentials
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
@@ -56,7 +57,8 @@ use_oauth_services = {{group}}_{{role | lower}}
 use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% endif %}
-{% if role is defined %}
+{% endif %}
+{% if role is defined and proxy is defined and proxy %}
 +x509userproxy = "{{proxy}}"
 delegate_job_GSI_credentials_lifetime = 0
 {% endif %}

--- a/templates/dataset_dag/sambegin.sh
+++ b/templates/dataset_dag/sambegin.sh
@@ -1,11 +1,13 @@
 #!/bin/sh -x
 
+{% if token is defined and token %}
 {% if role and role != 'Analysis' %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}_{{oauth_handle}}.use
 {% else %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{oauth_handle}}.use
+{% endif %}
 {% endif %}
 
 redirect_output_start(){

--- a/templates/dataset_dag/samend.sh
+++ b/templates/dataset_dag/samend.sh
@@ -1,11 +1,13 @@
 #!/bin/sh -x
 
+{% if token is defined and token %}
 {% if role and role != 'Analysis' %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}_{{oauth_handle}}.use
 {% else %}
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{oauth_handle}}.use
+{% endif %}
 {% endif %}
 
 redirect_output_start(){

--- a/templates/maxconcurrent_dag/maxconcurrent.dag.condor.sub
+++ b/templates/maxconcurrent_dag/maxconcurrent.dag.condor.sub
@@ -48,6 +48,7 @@ notification = Always
 +JobsubUUID="{{uuid}}"
 
 # Credentials
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {{group}}_{{role | lower}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
@@ -55,7 +56,8 @@ use_oauth_services = {{group}}_{{role | lower}}
 use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% endif %}
-{% if role is defined %}
+{% endif %}
+{% if role is defined and proxy is defined and proxy %}
 +x509userproxy = "{{proxy}}"
 delegate_job_GSI_credentials_lifetime = 0
 {% endif %}

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -105,7 +105,7 @@ use_oauth_services = {{group}}
 {% else %}
 +x509userproxy = "{{proxy}}"
 {% endif %}
-delegate_job_GSI_credentials_lifetime = 0   # Do not delegate proxy and curtail its lifetime - use whatever proxy was submitted with the job
+delegate_job_GSI_credentials_lifetime = 0
 {% endif %}
 
 queue {{N}}

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -13,7 +13,7 @@ log                = {{filebase}}.log
 JOBSUBJOBSECTION=$(Process)
 {%endif%}
 
-environment        = CM1=$(CM1);CM2=$(CM2);CLUSTER=$(Cluster);PROCESS=$(Process);JOBSUBJOBSECTION=$(JOBSUBJOBSECTION);CONDOR_TMP={{outdir}};BEARER_TOKEN_FILE=.condor_creds/{% if role is defined and role and role != 'Analysis' %}{{group}}_{{role | lower}}_{{oauth_handle}}.use{%else%}{{group}}_{{oauth_handle}}.use{%endif%};CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
+environment        = CM1=$(CM1);CM2=$(CM2);CLUSTER=$(Cluster);PROCESS=$(Process);JOBSUBJOBSECTION=$(JOBSUBJOBSECTION);CONDOR_TMP={{outdir}};{% if token is defined and token %}BEARER_TOKEN_FILE=.condor_creds/{% if role is defined and role and role != 'Analysis' %}{{group}}_{{role | lower}}_{{oauth_handle}}.use{%else%}{{group}}_{{oauth_handle}}.use{%endif%}{% endif %};CONDOR_EXEC=/tmp;DAGMANJOBID=$(DAGManJobId);GRID_USER={{user}};JOBSUBJOBID=$(CLUSTER).$(PROCESS)@{{schedd}};EXPERIMENT={{group}};{{environment|join(';')}}
 rank               = Mips / 2 + Memory
 job_lease_duration = 3600
 transfer_output    = True
@@ -86,6 +86,7 @@ requirements  = {%if overwrite_requirements is defined and overwrite_requirement
 #
 
 # Credentials
+{% if token is defined and token %}
 {% if role is defined and role != 'Analysis' %}
 use_oauth_services = {{group}}_{{role | lower}}
 {% if job_scope is defined and job_scope %}
@@ -97,13 +98,14 @@ use_oauth_services = {{group}}
 {{group}}_oauth_permissions_{{oauth_handle}} = " {{job_scope}} "
 {% endif %}
 {% endif %}
-{% if role is defined %}
+{% endif %}
+{% if role is defined and proxy is defined and proxy %}
 {% if is_dag|default(False) %}
 +x509userproxy = "{{proxy|basename}}"
 {% else %}
 +x509userproxy = "{{proxy}}"
 {% endif %}
-delegate_job_GSI_credentials_lifetime = 0
+delegate_job_GSI_credentials_lifetime = 0   # Do not delegate proxy and curtail its lifetime - use whatever proxy was submitted with the job
 {% endif %}
 
 queue {{N}}

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -25,12 +25,14 @@ then
     unset BEARER_TOKEN_FILE
 else
 
+{% if token is defined and token %}
 {% if role is defined and role and role != 'Analysis' %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}_{{oauth_handle}}.use
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{role | lower}}.use
 {% else %}
 export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}_{{oauth_handle}}.use
 #export BEARER_TOKEN_FILE=$PWD/.condor_creds/{{group}}.use
+{% endif %}
 {% endif %}
 
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,16 @@ def clear_x509_user_proxy():
 
 
 @pytest.fixture
+def clear_bearer_token_file():
+    """Clear environment variable BEARER_TOKEN_FILE to test credentials overrides"""
+    old_bearer_token_file_value = os.environ.pop("BEARER_TOKEN_FILE", None)
+    yield
+
+    if old_bearer_token_file_value is not None:
+        os.environ["BEARER_TOKEN_FILE"] = old_bearer_token_file_value
+
+
+@pytest.fixture
 def check_user_kerberos_creds():
     """Make sure we have kerberos credentials before starting the test"""
     proc = subprocess.run(

--- a/tests/data/auth_methods_args_bad.json
+++ b/tests/data/auth_methods_args_bad.json
@@ -1,5 +1,9 @@
 [
     {
+        "cmdline_args": "proxy",
+        "bad_auth_method": "proxy"
+    },
+    {
         "cmdline_args": "token,BADSTUFF",
         "bad_auth_method": "BADSTUFF"
     },

--- a/tests/data/auth_methods_args_bad.json
+++ b/tests/data/auth_methods_args_bad.json
@@ -1,0 +1,18 @@
+[
+    {
+        "cmdline_args": "token,BADSTUFF",
+        "bad_auth_method": "BADSTUFF"
+    },
+    {
+        "cmdline_args": "proxy,BADSTUFF",
+        "bad_auth_method": "BADSTUFF"
+    },
+    {
+        "cmdline_args": "token,proxy,BADSTUFF",
+        "bad_auth_method": "BADSTUFF"
+    },
+    {
+        "cmdline_args": "BADSTUFF",
+        "bad_auth_method": "BADSTUFF"
+    }
+]

--- a/tests/data/auth_methods_args_good.json
+++ b/tests/data/auth_methods_args_good.json
@@ -1,0 +1,18 @@
+[
+    {
+        "cmdline_args": "token,proxy",
+        "auth_methods_result": "token,proxy"
+    },
+    {
+        "cmdline_args": "proxy",
+        "auth_methods_result": "proxy"
+    },
+    {
+        "cmdline_args": "token",
+        "auth_methods_result": "token"
+    },
+    {
+        "cmdline_args": "",
+        "auth_methods_result": "token,proxy"
+    }
+]

--- a/tests/data/auth_methods_args_good.json
+++ b/tests/data/auth_methods_args_good.json
@@ -4,10 +4,6 @@
         "auth_methods_result": "token,proxy"
     },
     {
-        "cmdline_args": "proxy",
-        "auth_methods_result": "proxy"
-    },
-    {
         "cmdline_args": "token",
         "auth_methods_result": "token"
     },

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+import json
 import os
 import sys
 import pytest
@@ -19,6 +21,54 @@ else:
     sys.path.append("../lib")
 import creds
 from test_unit import TestUnit
+
+DATADIR = f"{os.path.abspath(os.path.dirname(__file__))}/data"
+
+
+@pytest.fixture
+def check_valid_auth_method_arg_parser():
+    """This fixture sets up a lightweight ArgumentParser to test the --auth-methods flag"""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--auth-methods",
+        action=creds.CheckIfValidAuthMethod,
+        default=os.environ.get(
+            "JOBSUB_AUTH_METHODS", ",".join(creds.SUPPORTED_AUTH_METHODS)
+        ),
+    )
+    return parser
+
+
+def get_auth_methods_test_data_good():
+    """Pull in test data from data file and return a list of
+    test cases"""
+    AuthMethodsArgsTestCase = namedtuple(
+        "AuthMethodsArgsTestCase",
+        ["cmdline_args", "auth_methods_result"],
+    )
+
+    DATA_FILENAME = "auth_methods_args_good.json"
+    with open(f"{DATADIR}/{DATA_FILENAME}", "r") as datafile:
+        tests_json = json.load(datafile)
+
+    return [AuthMethodsArgsTestCase(**test_json) for test_json in tests_json]
+
+
+def get_auth_methods_test_data_bad():
+    """Pull in test data from data file and return a list of
+    test cases"""
+    AuthMethodsArgsTestCase = namedtuple(
+        "AuthMethodsArgsTestCase",
+        ["cmdline_args", "bad_auth_method"],
+    )
+
+    DATA_FILENAME = "auth_methods_args_bad.json"
+    with open(f"{DATADIR}/{DATA_FILENAME}", "r") as datafile:
+        tests_json = json.load(datafile)
+
+    return [AuthMethodsArgsTestCase(**test_json) for test_json in tests_json]
 
 
 class TestCredUnit:
@@ -48,5 +98,78 @@ class TestCredUnit:
         _ = creds.get_creds(args)
         assert args["role"] == "Analysis"
 
+    @pytest.mark.unit
+    def test_get_creds_token_only(self, clear_x509_user_proxy, clear_bearer_token_file):
+        """Get only a token"""
+        args = {"auth_methods": "token"}
+        os.environ["GROUP"] = TestUnit.test_group
+        cred_set = creds.get_creds(args)
+        # Make sure we have a token and the env is set
+        assert os.path.exists(os.environ["BEARER_TOKEN_FILE"])
+        assert os.path.exists(cred_set.token)
+        # Make sure the X509_USER_PROXY is not set
+        assert os.environ.get("X509_USER_PROXY", None) is None
 
-# TODO:  Tests for 1) proxy only, 2) token only
+    @pytest.mark.unit
+    def test_get_creds_proxy_only(self, clear_x509_user_proxy, clear_bearer_token_file):
+        """Get only a proxy"""
+        args = {"auth_methods": "proxy"}
+        os.environ["GROUP"] = TestUnit.test_group
+        cred_set = creds.get_creds(args)
+        # Make sure we have a proxy and the env is set
+        assert os.path.exists(os.environ["X509_USER_PROXY"])
+        assert os.path.exists(cred_set.proxy)
+        # Make sure the BEARER_TOKEN_FILE is not set
+        assert os.environ.get("BEARER_TOKEN_FILE", None) is None
+
+    @pytest.mark.unit
+    def test_get_creds_invalid_auth(
+        self, clear_x509_user_proxy, clear_bearer_token_file
+    ):
+        """This should never happen as the get_parser custom action should catch this and
+        raise an Exception, but just in case we get past it"""
+        args = {"auth_methods": "fakeauth"}
+        os.environ["GROUP"] = TestUnit.test_group
+        cred_set = creds.get_creds(args)
+        assert cred_set.token is None
+        assert cred_set.proxy is None
+        # Make sure BEARER_TOKEN_FILE, X509_USER_PROXY are not set
+        assert os.environ.get("BEARER_TOKEN_FILE", None) is None
+        assert os.environ.get("X509_USER_PROXY", None) is None
+
+    @pytest.mark.unit
+    def test_print_cred_paths_from_credset(self, capsys):
+        cred_set = creds.CredentialSet(token="tokenlocation", proxy="proxylocation")
+        creds.print_cred_paths_from_credset(cred_set)
+        out, _ = capsys.readouterr()
+        assert out == (
+            "token location: tokenlocation\n" "proxy location: proxylocation\n"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "auth_methods_args_test_case",
+        get_auth_methods_test_data_good(),
+    )
+    def test_CheckIfValidAuthMethod_good(
+        self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
+    ):
+        args = check_valid_auth_method_arg_parser.parse_args(
+            ["--auth-methods", auth_methods_args_test_case.cmdline_args]
+        )
+        assert args.auth_methods == auth_methods_args_test_case.auth_methods_result
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "auth_methods_args_test_case",
+        get_auth_methods_test_data_bad(),
+    )
+    def test_CheckIfValidAuthMethod_bad(
+        self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
+    ):
+        with pytest.raises(
+            TypeError, match=auth_methods_args_test_case.bad_auth_method
+        ):
+            args = check_valid_auth_method_arg_parser.parse_args(
+                ["--auth-methods", auth_methods_args_test_case.cmdline_args]
+            )

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -33,11 +33,11 @@ class TestCredUnit:
         """get credentials, make sure the credentials files returned
         exist"""
         os.environ["GROUP"] = TestUnit.test_group
-        proxy, token = creds.get_creds()
+        cred_set = creds.get_creds()
         assert os.path.exists(os.environ["X509_USER_PROXY"])
         assert os.path.exists(os.environ["BEARER_TOKEN_FILE"])
-        assert os.path.exists(proxy)
-        assert os.path.exists(token)
+        assert os.path.exists(cred_set.proxy)
+        assert os.path.exists(cred_set.token)
 
     @pytest.mark.unit
     def test_get_creds_default_role(self):
@@ -45,5 +45,8 @@ class TestCredUnit:
         exist"""
         args = {}
         os.environ["GROUP"] = TestUnit.test_group
-        _, _ = creds.get_creds(args)
+        _ = creds.get_creds(args)
         assert args["role"] == "Analysis"
+
+
+# TODO:  Tests for 1) proxy only, 2) token only

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -65,12 +65,8 @@ class TestCredUnit:
         """Get only a proxy"""
         args = {"auth_methods": "proxy"}
         os.environ["GROUP"] = TestUnit.test_group
-        cred_set = creds.get_creds(args)
-        # Make sure we have a proxy and the env is set
-        assert os.path.exists(os.environ["X509_USER_PROXY"])
-        assert os.path.exists(cred_set.proxy)
-        # Make sure the BEARER_TOKEN_FILE is not set
-        assert os.environ.get("BEARER_TOKEN_FILE", None) is None
+        with pytest.raises(TypeError, match="Missing required authorization method"):
+            creds.get_creds(args)
 
     @pytest.mark.unit
     def test_get_creds_invalid_auth(
@@ -80,12 +76,8 @@ class TestCredUnit:
         raise an Exception, but just in case we get past it"""
         args = {"auth_methods": "fakeauth"}
         os.environ["GROUP"] = TestUnit.test_group
-        cred_set = creds.get_creds(args)
-        assert cred_set.token is None
-        assert cred_set.proxy is None
-        # Make sure BEARER_TOKEN_FILE, X509_USER_PROXY are not set
-        assert os.environ.get("BEARER_TOKEN_FILE", None) is None
-        assert os.environ.get("X509_USER_PROXY", None) is None
+        with pytest.raises(TypeError, match="Missing required authorization method"):
+            creds.get_creds(args)
 
     @pytest.mark.unit
     def test_print_cred_paths_from_credset(self, capsys):

--- a/tests/test_creds_unit.py
+++ b/tests/test_creds_unit.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-import json
 import os
 import sys
 import pytest
@@ -21,54 +19,6 @@ else:
     sys.path.append("../lib")
 import creds
 from test_unit import TestUnit
-
-DATADIR = f"{os.path.abspath(os.path.dirname(__file__))}/data"
-
-
-@pytest.fixture
-def check_valid_auth_method_arg_parser():
-    """This fixture sets up a lightweight ArgumentParser to test the --auth-methods flag"""
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--auth-methods",
-        action=creds.CheckIfValidAuthMethod,
-        default=os.environ.get(
-            "JOBSUB_AUTH_METHODS", ",".join(creds.SUPPORTED_AUTH_METHODS)
-        ),
-    )
-    return parser
-
-
-def get_auth_methods_test_data_good():
-    """Pull in test data from data file and return a list of
-    test cases"""
-    AuthMethodsArgsTestCase = namedtuple(
-        "AuthMethodsArgsTestCase",
-        ["cmdline_args", "auth_methods_result"],
-    )
-
-    DATA_FILENAME = "auth_methods_args_good.json"
-    with open(f"{DATADIR}/{DATA_FILENAME}", "r") as datafile:
-        tests_json = json.load(datafile)
-
-    return [AuthMethodsArgsTestCase(**test_json) for test_json in tests_json]
-
-
-def get_auth_methods_test_data_bad():
-    """Pull in test data from data file and return a list of
-    test cases"""
-    AuthMethodsArgsTestCase = namedtuple(
-        "AuthMethodsArgsTestCase",
-        ["cmdline_args", "bad_auth_method"],
-    )
-
-    DATA_FILENAME = "auth_methods_args_bad.json"
-    with open(f"{DATADIR}/{DATA_FILENAME}", "r") as datafile:
-        tests_json = json.load(datafile)
-
-    return [AuthMethodsArgsTestCase(**test_json) for test_json in tests_json]
 
 
 class TestCredUnit:
@@ -145,31 +95,3 @@ class TestCredUnit:
         assert out == (
             "token location: tokenlocation\n" "proxy location: proxylocation\n"
         )
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "auth_methods_args_test_case",
-        get_auth_methods_test_data_good(),
-    )
-    def test_CheckIfValidAuthMethod_good(
-        self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
-    ):
-        args = check_valid_auth_method_arg_parser.parse_args(
-            ["--auth-methods", auth_methods_args_test_case.cmdline_args]
-        )
-        assert args.auth_methods == auth_methods_args_test_case.auth_methods_result
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "auth_methods_args_test_case",
-        get_auth_methods_test_data_bad(),
-    )
-    def test_CheckIfValidAuthMethod_bad(
-        self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
-    ):
-        with pytest.raises(
-            TypeError, match=auth_methods_args_test_case.bad_auth_method
-        ):
-            args = check_valid_auth_method_arg_parser.parse_args(
-                ["--auth-methods", auth_methods_args_test_case.cmdline_args]
-            )

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -618,3 +618,28 @@ class TestGetParserUnit:
             check_valid_auth_method_arg_parser.parse_args(
                 ["--auth-methods", auth_methods_args_test_case.cmdline_args]
             )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "auth_method_env_setting",
+        ["token,proxy", "token", "icansneakthisinbydesign,token"],
+    )
+    def test_set_auth_methods_environ(
+        self, auth_method_env_setting, check_valid_auth_method_arg_parser
+    ):
+        """Check that we can set the auth methods via the environment variable
+        JOBSUB_AUTH_METHODS.  Test both a valid case and invalid.  The latter
+        would be caught by the underlying library code, by design"""
+        old_auth_methods_env_value = os.environ.pop("JOBSUB_AUTH_METHODS", None)
+
+        # Valid case
+        os.environ["JOBSUB_AUTH_METHODS"] = auth_method_env_setting
+        args = check_valid_auth_method_arg_parser.parse_args([])
+        try:
+            assert (
+                args.auth_methods.split(",").sort()
+                == auth_method_env_setting.split(",").sort()
+            )
+        finally:
+            if old_auth_methods_env_value:
+                os.environ["JOBSUB_AUTH_METHODS"] = old_auth_methods_env_value

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -524,6 +524,3 @@ class TestGetParserUnit:
             schedd_for_testing_arg_parser.parse_args(
                 ["--schedd-for-testing", "this_is_an_invalid_schedd.domain"]
             )
-
-
-# TODO Need tests for --auth-methods flag

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -588,6 +588,8 @@ class TestGetParserUnit:
     def test_CheckIfValidAuthMethod_good(
         self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
     ):
+        """For valid auth method combinations, make sure we get the right
+        auth methods stored by the parser"""
         args = check_valid_auth_method_arg_parser.parse_args(
             ["--auth-methods", auth_methods_args_test_case.cmdline_args]
         )
@@ -604,6 +606,9 @@ class TestGetParserUnit:
     def test_CheckIfValidAuthMethod_bad(
         self, auth_methods_args_test_case, check_valid_auth_method_arg_parser
     ):
+        """For invalid auth method argument values, make sure we get a TypeError
+        raised that either includes the invalid method, or tells us what the required
+        auth methods are"""
         from creds import REQUIRED_AUTH_METHODS
 
         with pytest.raises(

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -137,6 +137,7 @@ def find_all_arguments(paired_arguments):
 @pytest.fixture
 def all_test_args():
     return [
+        "--auth-methods",
         "--append-condor-requirements",
         "xxappend-condor-requirementsxx",
         "--blocklist",
@@ -347,6 +348,7 @@ class TestGetParserUnit:
         # e.g. For the mutually exclusive group (--singularity-image,
         # --no-singularity), we pick one and enter it into args_exclude_list
         args_exclude_list = [
+            "--auth-methods",  # We do a special test for this
             "--no-singularity",
             "--apptainer-image",
             "--no-apptainer",
@@ -522,3 +524,6 @@ class TestGetParserUnit:
             schedd_for_testing_arg_parser.parse_args(
                 ["--schedd-for-testing", "this_is_an_invalid_schedd.domain"]
             )
+
+
+# TODO Need tests for --auth-methods flag

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -42,6 +42,8 @@ class TestUnit:
         "generate_email_summary": False,
         "dd_percentage": 100,
         "dd_extra_dataset": [],
+        "token": "faketokenpathtomaketestwork",
+        "proxy": "fakeproxypathtomaketestwork",
     }
     test_extra_template_args = {
         "role": test_role,

--- a/tests/test_utils_unit.py
+++ b/tests/test_utils_unit.py
@@ -175,9 +175,11 @@ class TestUtilsUnit:
     def test_set_extras_1(self, needs_credentials):
         """call set_extras_n_fix_units, verify one thing from environment
         and one unit conversion..."""
-        proxy, token = needs_credentials
+        cred_set = needs_credentials
         args = TestUnit.test_vargs.copy()
-        utils.set_extras_n_fix_units(args, TestUnit.test_schedd, proxy, token)
+        utils.set_extras_n_fix_units(
+            args, TestUnit.test_schedd, cred_set.proxy, cred_set.token
+        )
         assert args["user"] == os.environ["USER"]
         assert args["memory"] == 64 * 1024
 
@@ -186,21 +188,21 @@ class TestUtilsUnit:
         self, needs_credentials, clear_x509_user_proxy
     ):
         """Call get_client_dn with proxy specified"""
-        _proxy, _ = needs_credentials
+        cred_set = needs_credentials
         clear_x509_user_proxy
-        client_dn = utils.get_client_dn(proxy=_proxy)
+        client_dn = utils.get_client_dn(proxy=cred_set.proxy)
         assert os.environ["USER"] in client_dn
 
     @pytest.mark.unit
     def test_get_client_dn_env_plus_proxy_provided(self, needs_credentials):
         """Call get_client_dn with proxy specified, env set.  Should grab
         proxy from passed-in arg"""
-        _proxy, _ = needs_credentials
+        cred_set = needs_credentials
         old_x509_user_proxy_value = os.environ.pop("X509_USER_PROXY", None)
         os.environ[
             "X509_USER_PROXY"
         ] = "foobar"  # Break the environment so that this test won't accidentally pass
-        client_dn = utils.get_client_dn(proxy=_proxy)
+        client_dn = utils.get_client_dn(proxy=cred_set.proxy)
         assert os.environ["USER"] in client_dn
         os.environ["X509_USER_PROXY"] = old_x509_user_proxy_value
 
@@ -208,7 +210,6 @@ class TestUtilsUnit:
     def test_get_client_dn_no_proxy_provided(self, needs_credentials):
         """Call get_client_dn with no proxy specified.  Should grab proxy from
         env"""
-        _proxy, _ = needs_credentials  # Sets $X509_USER_PROXY
         client_dn = utils.get_client_dn()
         assert os.environ["USER"] in client_dn
 
@@ -218,7 +219,6 @@ class TestUtilsUnit:
     ):
         """Call get_client_dn with no proxy specified, environment not set.
         Should get proxy from standard grid location"""
-        _proxy, _ = needs_credentials
         clear_x509_user_proxy
         client_dn = utils.get_client_dn()
         assert os.environ["USER"] in client_dn


### PR DESCRIPTION
This is a massive PR, so please take your time going through it.  It adds a few things:

1. A couple of constants where we configure which auth methods are defaulted to, and which are required by our infrastructure (`creds.DEFAULT_AUTH_METHODS`, `creds.REQUIRED_AUTH_METHODS`).
2.  A new object, `creds.CredentialSet`, that stores the paths to the various supported credential types.  Its instantiation automatically stores the paths to the credentials in the correct environment variables (e.g. `BEARER_TOKEN_FILE`.
3.  A new argument, `--auth-methods`, that can be passed in.  So `--auth-methods token` requests only a token, `--auth-methods "proxy,token"` requests both, etc.  There are safeguards in place at both the parser level and the underlying creds code (see next item) to prevent invalid auth methods from being requested.  The order of preference is:
  1. `--auth-methods` flag
  2. `JOBSUB_AUTH_METHODS` environment variable
  3. `creds.DEFAULT_AUTH_METHODS` list
4. `creds.get_creds()` now will check the requested auth methods to make sure that they include the `REQUIRED_AUTH_METHODS`, and will return a `CredentialSet`.  Since most callers don't actually do anything with the return value of `get_creds()` and simply use it to ensure credentials are refreshed and in the environment, I didn't need to change much on the caller end.
5. Unit tests to test all of this.

The tests I ran aside from the unit tests are listed in #270, so please feel free to take a look.  Let me know if you have any questions.