### PR TITLE
tarfile file-size checks

### DIFF
--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -47,6 +47,8 @@ except ValueError:
     )
     raise
 
+RCDS_MAX_FILE_SIZE = 1073741824
+
 
 class TokenAuth(AuthBase):  # type: ignore
     # auth class for token authentication
@@ -92,7 +94,7 @@ def tarchmod(tfn: str) -> str:
                 else:
                     st = fin.extractfile(ti)
                 ti.mode = ti.mode | 0o755
-                if ti.size > 1073741824:
+                if ti.size > RCDS_MAX_FILE_SIZE:
                     raise ValueError(
                         f"file '{ti.name}' in your tarfile {tfn}\n"
                         f"  size {ti.size/1024}k is over RCDS 1G limit\n"

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -73,7 +73,11 @@ def check_we_can_write() -> None:
 
 
 def tarchmod(tfn: str) -> str:
-    """copy a tarfile to a compressed tarfile changing modes of contents to 755"""
+    """
+    copy a tarfile to a compressed tarfile, while:
+    * changing modes of contents to 755
+    * bailing if tarfile has files too large for RCDS
+    """
     ofn = os.path.basename(f"{tfn}{os.getpid()}.tbz2")
     check_we_can_write()
     try:
@@ -88,6 +92,11 @@ def tarchmod(tfn: str) -> str:
                 else:
                     st = fin.extractfile(ti)
                 ti.mode = ti.mode | 0o755
+                if ti.size > 1073741824:
+                    raise ValueError(
+                        f"file '{ti.name}' in your tarfile {tfn}\n"
+                        f"  size {ti.size/1024}k is over RCDS 1G limit\n"
+                    )
                 fout.addfile(ti, st)
                 ti = fin.next()
     except tarfile_mod.TarError:


### PR DESCRIPTION
Checking the file size while we convert tarfiles, and raising an exception for files > 1G, which would fail later when and RCDS upload is attempted.