### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = jobsub_lite
-VERSION = v1.4
+VERSION = v1.4.1
 ROOTDIR = $(shell pwd)
 rpmVersion := $(subst v,,$(VERSION))
 BUILD_DIR = $(NAME)-$(rpmVersion)

--- a/lib/version.py
+++ b/lib/version.py
@@ -18,7 +18,7 @@ __title__ = "jobsub_lite"
 __summary__ = "The local HTCondor job submission software for Fermilab users to submit jobs to local FermiGrid resources and to the Open Science Grid."
 __uri__ = "https://fifewiki.fnal.gov/wiki/Jobsub_Lite"
 
-__version__ = "1.4"
+__version__ = "1.4.1"
 __email__ = "jobsub-support@fnal.gov"
 
 __license__ = "Apache License, Version 2.0"


### PR DESCRIPTION
This will be a draft until the following PR:

https://github.com/fermitools/jobsub_lite_config/pull/18/

is merged.  We may need to update the config commit hash.