### PR TITLE
Fix totals again

### DIFF
--- a/bin/jobsub_totals
+++ b/bin/jobsub_totals
@@ -19,7 +19,7 @@ type_map = OrderedDict(
 )
 
 totals = defaultdict(lambda: 0)
-totals["T"] = -1  # offset for jobsub_q heading line
+totals["T"] = 0
 
 for line in sys.stdin.readlines():
     print(line, end="")

--- a/tests/data/jq_out.txt
+++ b/tests/data/jq_out.txt
@@ -1,4 +1,3 @@
-JOBSUBJOBID                             OWNER       	SUBMITTED     RUNTIME   ST PRIO   SIZE  COMMAND
 66882383.0@jobsub02.fnal.gov            user1   	03/30 11:38   0+00:00:00 I    0    0.0 submission_test_stashcache.sh
 66882383.1@jobsub02.fnal.gov            user1   	03/30 11:38   0+00:00:00 I    0    0.0 submission_test_stashcache.sh
 66882383.2@jobsub02.fnal.gov            user1   	03/30 11:38   0+00:00:00 I    0    0.0 submission_test_stashcache.sh

--- a/tests/test_jobsub_totals.py
+++ b/tests/test_jobsub_totals.py
@@ -29,4 +29,4 @@ class TestJobsubTotals:
             last
             == "1862 total; 15 completed, 0 removed, 64 idle, 1748 running, 35 held, 0 suspended\n"
         )
-        assert count == 1864
+        assert count == 1863


### PR DESCRIPTION
Since the changes in #358 , the jobsub_q headings don't get piped through jobsub_totals anymore, but the totals script was still taking one off the number of lines for the total to account for the heading... 

Updated jobsub_totals, and took the heading out if its test-case data.