### PR TITLE
Don't assume we have GROUP set in the environment

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -128,15 +128,13 @@ def getExp() -> str:
 @as_span("getRole")
 def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
     """get current role"""
-
     if role_override:
         return role_override
 
     # if we have a default role pushed with a vault token, or $HOME/.jobsub_default... use that
     uid = os.getuid()
-    # sometimes we're called before parsing args, so GROUP may not be
-    # set yet...
-    group = os.environ.get("GROUP", "unknown")
+    environ_group = os.environ.get("GROUP")
+    group = environ_group if environ_group else getExp()
 
     for prefix in ["/tmp/", f"{os.environ['HOME']}/.config/"]:
         fname = f"{prefix}jobsub_default_role_{group}_{uid}"

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -121,7 +121,7 @@ def getExp() -> str:
     # otherwise guess primary group...
     exp: str
     with os.popen("id -gn", "r") as f:
-        exp = f.read()
+        exp = f.read().strip()
     return exp
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,8 @@ def check_user_kerberos_creds():
         raise Exception(
             f"No kerberos credentials found.  Please run kinit and try again.  Error: {proc.stdout}"
         )
+
+
+@pytest.fixture
+def set_group_fermilab(monkeypatch):
+    monkeypatch.setenv("GROUP", "fermilab")

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -65,7 +65,7 @@ def test_getExp_GROUP():
 
 
 @pytest.mark.unit
-def test_getRole():
+def test_getRole(set_group_fermilab):
     res = fake_ifdh.getRole()
     assert res == fake_ifdh.DEFAULT_ROLE
 

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -1,5 +1,7 @@
+import grp
 import os
 import pathlib
+import pwd
 import shutil
 import sys
 import tempfile
@@ -58,11 +60,21 @@ def test_getTmp_override(monkeypatch):
     assert res == "/var/tmp"
 
 
-@pytest.mark.unit
-def test_getExp_GROUP(monkeypatch):
-    monkeypatch.setenv("GROUP", "samdev")
-    res = fake_ifdh.getExp()
-    assert res == "samdev"
+class TestGetExp:
+    @pytest.mark.unit
+    def test_getExp_GROUP(self, monkeypatch):
+        monkeypatch.setenv("GROUP", "samdev")
+        res = fake_ifdh.getExp()
+        assert res == "samdev"
+
+    @pytest.mark.unit
+    def test_getExp_no_GROUP(self, monkeypatch):
+        monkeypatch.delenv("GROUP", raising=False)
+        # Adapted from https://stackoverflow.com/a/9324811
+        user = pwd.getpwuid(os.getuid()).pw_name
+        gid = pwd.getpwnam(user).pw_gid
+        expected_group = grp.getgrgid(gid).gr_name
+        assert fake_ifdh.getExp() == expected_group
 
 
 # Various getRole tests


### PR DESCRIPTION
Closes #507 

The main changes in this PR are as follows:

1.  If GROUP is not set in the environment, `getRole` calls `getExp` to get the group.  Previously, we would run into a `KeyError` in this case. 
2. Refactored `getRole` by extracting two functions that explain what we're checking to get the role:  `getRole_from_default_role_file` and `getRole_from_valid_token`.  This cleans up the `getRole` code and makes the logic much clearer.
3. Fixed bug in `getExp` where we didn't strip the newline character from the fallthrough `id -gn` case, and added a test for that case.
4. Lots of unit test refactoring in `test_fake_ifdh.py` to group the tests into classes, since we (rightly so) have multiple tests per `fake_ifdh.py` function.  I also parametrized tests where it made sense.