### PR TITLE
Improvements to TarfilePublisherHandler

### DIFF
--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -488,6 +488,12 @@ class TarfilePublisherHandler:
                     self._fixed_server and always_switch_servers
                 )
 
+                if should_change_selector_behavior and self.verbose:
+                    print(
+                        "TarfilePublisherHandler is configured to use a fixed RCDS server, however this is being overridden "
+                        "for the duration of the current request."
+                    )
+
                 _retry_interval_sec = 0  # First retry immediately, and then we can wait the retry interval
                 # pylint: disable-next=protected-access
                 retry_count = itertools.count(1)
@@ -538,6 +544,10 @@ class TarfilePublisherHandler:
                         _retry_interval_sec = RETRY_INTERVAL_SEC
                     else:
                         if should_change_selector_behavior:
+                            if self.verbose:
+                                print(
+                                    "Restoring fixed server behavior of TarfilePublisherHandler"
+                                )
                             self.__restore_fixed_server_behavior()
                         break
                 return response

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -331,12 +331,15 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
         # cid looks something like dune/bf6a15b4238b72f82...(long hash)
         cid = f"{args.group}/{digest}"
 
-        publisher = TarfilePublisherHandler(cid, cred_set, args.verbose)
+        publisher = TarfilePublisherHandler(
+            cid=cid, cred_set=cred_set, fixed_server=True, verbose=args.verbose
+        )
         location = publisher.cid_exists()
         if location is None:
             if args.verbose:
                 print(f"\n\nUsing RCDS to publish tarball\ncid: {cid}")
             publisher.publish(tfn)
+            publisher.activate_server_switcher()
             if not getattr(args, "skip_check_rcds", False):
                 msg = "Checking to see if uploaded file is published on RCDS"
                 if args.verbose:

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -457,6 +457,7 @@ class TarfilePublisherHandler:
             if not self._fixed_server
             else self.__setup_fixed_dropbox_server()
         )
+        self.__last_server = next(self._dropbox_server_selector)
 
     # pylint: disable-next=no-self-argument
     def pubapi_operation(always_switch_servers: bool = False) -> Callable:  # type: ignore
@@ -478,15 +479,13 @@ class TarfilePublisherHandler:
 
                 # After this request, restore the appropriate fixed_server behavior
                 # pylint: disable=protected-access
-                __fixed_server = next(self._dropbox_server_selector)
-                __fixed_server_func: Callable[
-                    ..., Iterator[str]
-                ] = lambda: itertools.repeat(__fixed_server)
-                # pylint: disable=protected-access
-                restore_fixed_server_behavior_func = (
-                    __fixed_server_func
-                    if self._fixed_server
-                    else self.activate_server_switcher
+                # Logic here:
+                # 1. If self._fixed_server and always_switch_servers, we want to switch servers for only this request, and we should restore the behavior afterwards
+                # 2. If not self._fixed_server and always_switch_servers, everything is already set correctly.  Do nothing, restore nothing.
+                # 3. If self._fixed_server and not always_switch_servers, everything else already set correctly.  Do nothing, restore nothing.
+                # 4. If not self._fixed_server and not always_switch_servers, then we respect the self._fixed_server setting, and do nothing and restore nothing.
+                should_change_selector_behavior = (
+                    self._fixed_server and always_switch_servers
                 )
 
                 _retry_interval_sec = 0  # First retry immediately, and then we can wait the retry interval
@@ -497,6 +496,17 @@ class TarfilePublisherHandler:
                     try:
                         # pylint: disable=protected-access
                         _dropbox_server = next(self._dropbox_server_selector)
+
+                        # If we're supposed to be switching servers, make sure we are
+                        if (
+                            len(self.dropbox_server_string.split()) > 1
+                            and not self._fixed_server
+                            and _dropbox_server == self.__last_server
+                        ):
+                            _dropbox_server = next(self._dropbox_server_selector)
+
+                        self.__last_server = _dropbox_server
+
                         if self.verbose > 0:
                             print(f"Using PubAPI server {_dropbox_server}")
                         self.pubapi_base_url_formatter = (
@@ -520,14 +530,15 @@ class TarfilePublisherHandler:
                             raise
 
                         # If always_switch_servers is True, we should override the fixed_server setting for the duration of this request
-                        if next_retry_count == 1 and always_switch_servers:
+                        if next_retry_count == 1 and should_change_selector_behavior:
                             self.activate_server_switcher()
 
                         print(f"Will retry in {_retry_interval_sec} seconds")
                         time.sleep(_retry_interval_sec)
                         _retry_interval_sec = RETRY_INTERVAL_SEC
                     else:
-                        restore_fixed_server_behavior_func()
+                        if should_change_selector_behavior:
+                            self.restore_fixed_server_behavior_func()
                         break
                 return response
 
@@ -648,6 +659,13 @@ class TarfilePublisherHandler:
             raise NoPublisherHandlerServerError(
                 "No server was specified to publish the tarball.  Please check to ensure that JOBSUB_DROPBOX_SERVER_LIST is set in the environment"
             )
+
+    def restore_fixed_server_behavior_func(self) -> Callable[..., Iterator[str]]:
+        """This function is meant to be used when wanting to restore the behavior
+        of using a fixed dropbox server after activating the dropbox server switcher"""
+        __fixed_server = next(self._dropbox_server_selector)
+        self._fixed_server = True
+        return lambda: itertools.repeat(__fixed_server)
 
 
 class NoPublisherHandlerServerError(Exception):

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -477,8 +477,13 @@ class TarfilePublisherHandler:
 
                 # After this request, restore the appropriate fixed_server behavior
                 # pylint: disable=protected-access
+                __fixed_server = next(self._dropbox_server_selector)
+                __fixed_server_func: Callable[
+                    ..., Iterator[str]
+                ] = lambda: itertools.repeat(__fixed_server)
+                # pylint: disable=protected-access
                 restore_fixed_server_behavior_func = (
-                    self.deactivate_server_switcher
+                    __fixed_server_func
                     if self._fixed_server
                     else self.activate_server_switcher
                 )

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -353,10 +353,11 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
                         print("Found uploaded file on RCDS.")
                         break
                     if i < (NUM_RETRIES - 1):
+                        _retry_interval_sec = 0 if i == 0 else RETRY_INTERVAL_SEC
                         print(
-                            f"Could not locate uploaded file on RCDS.  Will retry in {RETRY_INTERVAL_SEC} seconds."
+                            f"Could not locate uploaded file on RCDS.  Will retry in {_retry_interval_sec} seconds."
                         )
-                        time.sleep(RETRY_INTERVAL_SEC)
+                        time.sleep(_retry_interval_sec)
                 else:
                     print(
                         f"Max retries {NUM_RETRIES} to find RCDS tarball at {cid} exceeded.  Exiting now."

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -538,7 +538,7 @@ class TarfilePublisherHandler:
                         _retry_interval_sec = RETRY_INTERVAL_SEC
                     else:
                         if should_change_selector_behavior:
-                            self.restore_fixed_server_behavior_func()
+                            self.__restore_fixed_server_behavior()
                         break
                 return response
 
@@ -660,7 +660,7 @@ class TarfilePublisherHandler:
                 "No server was specified to publish the tarball.  Please check to ensure that JOBSUB_DROPBOX_SERVER_LIST is set in the environment"
             )
 
-    def restore_fixed_server_behavior_func(self) -> Callable[..., Iterator[str]]:
+    def __restore_fixed_server_behavior(self) -> Callable[..., Iterator[str]]:
         """This function is meant to be used when wanting to restore the behavior
         of using a fixed dropbox server after activating the dropbox server switcher"""
         __fixed_server = next(self._dropbox_server_selector)


### PR DESCRIPTION
Closes #468 

This PR has a few changes to the way the `TarfilePublisherHandler` works:

1. `TarfilePublisherHandler` now accepts an argument `fixed_server` that determines whether or not it should switch servers between retries during a `pubapi_operation`.  The default value of this new argument is `False`, to keep in line with the old behavior.
2. There are new private and public methods to allow callers of `TarfilePublisherHandler` to switch fixed_server behavior on and off.
3. The function `tarfile_in_dropbox` uses (1) and (2) to make sure that the first `exists` call and subsequent `publish` call (if needed) go to the same RCDS server.  It then turns on server switching behavior for all subsequent `exists` calls.
4. The first time an RCDS operation fails, the `TarfilePublisherHandler` retries immediately, and THEN holds off for `RETRY_INTERVAL_SEC`.
5. The `publish` method of `TarfilePublisherHandler` will always switch servers for each retry, regardless of (1) or (2).  When the publish is finished, the `TarfilePublisherHandler` will restore its previous behavior, whether that was server switching or fixed server.
6. Fixed a minor bug with regard to server switching.  The `TarfilePublisherHandler` now keeps track of which server it last contacted, and if server switching is on (the default), then we make sure to actually switch servers each time.

(3) and (4) above are the main suggestions that @DrDaveD, @hgreenlee, and @vitodb raised to me at various points, and are the main drivers of #468 and this PR.