### PR TITLE
Added skip-check option called disk_space to skip disk quota checking

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -532,7 +532,7 @@ def get_parser() -> argparse.ArgumentParser:
         default=[],
         help="Skip checks that jobsub_lite does by default.  Add as many --skip-check "
         f"flags as desired.  Available checks are {SupportedSkipChecks.get_all_checks()}. "
-        "Example:  --skip-check rcds",
+        "Example:  --skip-check rcds --skip-check disk_space",
     )
     parser.add_argument(
         "--tar_file_name",

--- a/lib/render_files.py
+++ b/lib/render_files.py
@@ -55,8 +55,14 @@ def render_files(
     values["cwd"] = dest
 
     # make sure we have enough disk space...
-    if not utils.check_space(dest, min_kblocks=6 * len(flist), min_files=len(flist)):
-        raise RuntimeError(f"Insufficient disk space/quota in {dest} to submit job")
+    if not values.get("skip_check_disk_space", False):
+        if not utils.check_space(
+            dest, min_kblocks=6 * len(flist), min_files=len(flist)
+        ):
+            raise RuntimeError(f"Insufficient disk space/quota in {dest} to submit job")
+    else:
+        if getattr(values, "verbose", 0) > 0:
+            print(f"Skipping disk_space check in {dest}")
 
     for f in flist:
         if values["verbose"] > 0:

--- a/lib/skip_checks.py
+++ b/lib/skip_checks.py
@@ -47,6 +47,16 @@ def _print_rcds_warning() -> None:
     )
 
 
+def _print_disk_space_warning() -> None:
+    """This function prints out the warning for skipping disk quota checks"""
+    print(
+        "WARNING: You have elected to skip the disk quota check. "
+        "This check ensures that there are available disk space and file "
+        "handles in the locations jobsub needs to submit your jobs as "
+        "specified.  Skipping this check may result in failed job submissions.\n"
+    )
+
+
 # Supported Checks to Skip
 class SupportedSkipChecks(Enum):
     """Add checks to skip here, with the setup function they should call when skipped
@@ -64,6 +74,7 @@ class SupportedSkipChecks(Enum):
     """
 
     rcds = partial(_print_rcds_warning)  # pylint: disable=invalid-name
+    disk_space = partial(_print_disk_space_warning)  # pylint: disable=invalid-name
 
     # pylint: disable=consider-iterating-dictionary
     @classmethod

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -256,11 +256,12 @@ def set_extras_n_fix_units(
         # also make sure there is enough space...
         statinfo = os.stat(args["full_executable"])
         if statinfo:
-            need_blocks = int(statinfo.st_size / 1024) + 1
-            if not check_space(args["submitdir"], need_blocks):
-                raise RuntimeError(
-                    f"not enough free disk/quota in {args['submitdir']} to copy {args['full_executable']}."
-                )
+            if not args.get("skip_check_disk_space", False):
+                need_blocks = int(statinfo.st_size / 1024) + 1
+                if not check_space(args["submitdir"], need_blocks):
+                    raise RuntimeError(
+                        f"not enough free disk/quota in {args['submitdir']} to copy {args['full_executable']}."
+                    )
         else:
             raise RuntimeError(
                 f"Cannot stat() executable {args['full_executable']}, does it exist?"

--- a/man/man1/jobsub_submit.1
+++ b/man/man1/jobsub_submit.1
@@ -226,7 +226,8 @@ and '&&(CVMFS=="OSG")' to the job requirements
 --skip-check SKIP_CHECK
 Skip checks that jobsub_lite does by default. Add as
 many --skip-check flags as desired. Available checks
-are ['rcds']. Example: --skip-check rcds
+are ['rcds', 'disk_space']. Example: --skip-check rcds
+--skip-check disk_space
 .HP
 --tar-file-name dropbox://PATH/TO/TAR_FILE,
 --tar-file-name tardir://PATH/TO/DIRECTORY


### PR DESCRIPTION
Adds onto #521.  This PR introduces a new option to the `--skip-check` flag, called `disk_space`, that allows a user to run:

`jobsub_submit -G <group> --skip-check disk_space file:///path/to/executable`

That will disable the quota checks implemented in #521.  The default value for this setting is `False`, so the quota checks run by default.

This flag can also be run in combination with `--skip-check rcds`, so a user can skip either or both (or neither) of those checks.  I updated the helptext for `--skip-check` to reflect this.