### PR TITLE
Split build workflows into PR and push workflows

### DIFF
--- a/.github/workflows/build-al9-pull-request.yaml
+++ b/.github/workflows/build-al9-pull-request.yaml
@@ -1,9 +1,6 @@
-name: build-al9
+name: build-al9-pull-request
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     types:
       - closed
@@ -14,25 +11,6 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: "Build master with merged PR in AL9 container"
-    container:
-      image: almalinux:9.3-minimal
-    steps:
-      - name: Install tar and gzip
-        run: |
-          microdnf install -y tar
-          microdnf install -y gzip
-      - name: Check out jobsub_lite in runner
-        uses: actions/checkout@v4
-      - name: Check out jobsub_lite_config in runner
-        uses: actions/checkout@v4
-        with:
-          repository: fermitools/jobsub_lite_config
-          path: config
-          token: ${{ secrets.ACCESS_JOBSUB_LITE_CONFIG }}
-      - uses: ./.github/actions/build-with-make
-  pushed_commit:
-    runs-on: ubuntu-latest
-    name: "Build master after push in AL9 container"
     container:
       image: almalinux:9.3-minimal
     steps:

--- a/.github/workflows/build-al9-push.yaml
+++ b/.github/workflows/build-al9-push.yaml
@@ -1,0 +1,28 @@
+name: build-al9-push
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  pushed_commit:
+    runs-on: ubuntu-latest
+    name: "Build master after push in AL9 container"
+    container:
+      image: almalinux:9.3-minimal
+    steps:
+      - name: Install tar and gzip
+        run: |
+          microdnf install -y tar
+          microdnf install -y gzip
+      - name: Check out jobsub_lite in runner
+        uses: actions/checkout@v4
+      - name: Check out jobsub_lite_config in runner
+        uses: actions/checkout@v4
+        with:
+          repository: fermitools/jobsub_lite_config
+          path: config
+          token: ${{ secrets.ACCESS_JOBSUB_LITE_CONFIG }}
+      - uses: ./.github/actions/build-with-make

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/shreyb/jobsub_lite/master.svg)](https://results.pre-commit.ci/latest/github/shreyb/jobsub_lite/master)
-[![build-al9](https://github.com/fermitools/jobsub_lite/actions/workflows/build-al9.yaml/badge.svg)](https://github.com/fermitools/jobsub_lite/actions/workflows/build-al9.yaml)
-
+[![build-al9-push](https://github.com/fermitools/jobsub_lite/actions/workflows/build-al9-push.yaml/badge.svg)](https://github.com/fermitools/jobsub_lite/actions/workflows/build-al9-push.yaml)
 
 #  `jobsub_lite` Overview
 


### PR DESCRIPTION
No actual added or removed code here.  I just split up the push/PR jobs into two separate github actions, to avoid confusion about which is supposed to run when, and so we can tell at a glance which ran.