### PR TITLE
Checking token role and group should be case-insensitive

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -215,7 +215,7 @@ def checkToken_right_group_and_role(
     """Check if token in $BEARER_TOKEN_FILE is for right experiment"""
     token_groups_roles = get_and_verify_wlcg_groups_from_token(token)
     token_group, token_role = get_group_and_role_from_token_claim(token_groups_roles)
-    if token_group != group or token_role != role:
+    if token_group.lower() != group.lower() or token_role.lower() != role.lower():
         raise ValueError(
             "BEARER_TOKEN_FILE contains a token with the wrong group or role. "
             f"jobsub expects a token with group {group} and role {role}. "

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -268,6 +268,27 @@ class TestCheckTokenRightGroupAndRole:
         fake_ifdh.checkToken_right_group_and_role(token, group)
 
     @pytest.mark.unit
+    def test_good_with_role(self, clear_bearer_token_file, monkeypatch):
+        monkeypatch.setenv(
+            "BEARER_TOKEN_FILE", "fake_ifdh_tokens/fermilab_production.token"
+        )
+        group = "fermilab"
+        role = "production"
+        token = scitokens.SciToken.discover(insecure=True)
+        fake_ifdh.checkToken_right_group_and_role(token, group, role)
+
+    @pytest.mark.unit
+    def test_good_with_role_different_case(self, clear_bearer_token_file, monkeypatch):
+        """Should still pass because we should be case-insensitive"""
+        monkeypatch.setenv(
+            "BEARER_TOKEN_FILE", "fake_ifdh_tokens/fermilab_production.token"
+        )
+        group = "fermilab"
+        role = "Production"
+        token = scitokens.SciToken.discover(insecure=True)
+        fake_ifdh.checkToken_right_group_and_role(token, group, role)
+
+    @pytest.mark.unit
     def test_bad(self, bad_checkToken_test_case, clear_bearer_token_file, monkeypatch):
         monkeypatch.setenv("BEARER_TOKEN_FILE", bad_checkToken_test_case.token_location)
         group = bad_checkToken_test_case.group


### PR DESCRIPTION
Closes #531 

If a user runs `jobsub_submit -G uboone --role Production`, 1.6-rc1 would cause the submission to fail (using `--role production` was fine).  That would have been a breaking change based on the idea that jobsub should sanitize the case of the passed-in role.

This PR fixes that issue, and both `--role Production` and `--role  production` work now.