### PR TITLE
Changed DEFAULT_SINGULARITY_IMAGE to /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -628,7 +628,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--apptainer-image",
         default=DEFAULT_SINGULARITY_IMAGE,
         help="Singularity image to run jobs in.  Default is "
-        "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest",
     )
     singularity_group.add_argument(
         "--no-singularity",

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -38,7 +38,7 @@ import version
 ONSITE_SITE_NAME = "FermiGrid"
 DEFAULT_USAGE_MODELS = ["DEDICATED", "OPPORTUNISTIC", "OFFSITE"]
 DEFAULT_SINGULARITY_IMAGE = (
-    "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+    "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest"
 )
 
 
@@ -823,10 +823,10 @@ def resolve_singularity_image(
 
     # Parse lines.
     # Look for something like:
-    #     '+SingularityImage=\\\"/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest\\\"'
+    #     '+SingularityImage=\\\"/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest\\\"'
     # in lines and remove it while setting lines_singularity_image
     # In the above example, if there were such a line, lines_singularity_image would be set to
-    # "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+    # "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest"
     for line in lines:
         m = lines_singularity_re.match(line)
         if m:

--- a/tests/data/singularity_image.json
+++ b/tests/data/singularity_image.json
@@ -1,12 +1,12 @@
 [
     {
-        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest",
         "lines_arg": [
             "key1=value1",
             "key2=value2",
             "key3=value3"
         ],
-        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "expected_singularity_image": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest",
         "expected_lines": [
             "key1=value1",
             "key2=value2",
@@ -15,7 +15,7 @@
         "helptext": "--singularity_image=DEFAULT_SINGULARITY_IMAGE, --lines does not have SingularityImage:  DEFAULT_SINGULARITY_IMAGE, lines=old lines"
     },
     {
-        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest",
+        "singularity_image_arg": "/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest",
         "lines_arg": [
             "key1=value1",
             "key2=value2",


### PR DESCRIPTION
Addresses almost all of #535.  The only thing left after this PR is finished is to then send out an announcement with the change.

Note to reviewers:

I did not change any of the DAG tests that specify using the sl7 image, because using the sl7 image is a valid use case.  The only test I changed is the one that looks for the default image, which should now be el9.