### PR TITLE
Make sure --global-pool doesn't clear the pre-existing environment

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -295,8 +295,13 @@ def submit(
     # the updated one in the condor release
     #
     jldir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    cmd = f"_condor_SEC_CREDENTIAL_STORER={jldir}/bin/condor_vault_storer {cmd}"
-    #
+    _sec_cred_storer_val = (
+        f"{jldir}/bin/condor_vault_storer"
+        if not vargs.get("verbose")
+        else f'"{jldir}/bin/condor_vault_storer -v"'
+    )
+    cmd = f"_condor_SEC_CREDENTIAL_STORER={_sec_cred_storer_val} {cmd}"
+
     packages.orig_env()
     verbose = int(vargs.get("verbose", 0))
     if verbose > 0:

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -295,12 +295,15 @@ def submit(
     # the updated one in the condor release
     #
     jldir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    _sec_cred_storer_val = (
-        f"{jldir}/bin/condor_vault_storer"
-        if not vargs.get("verbose")
-        else f'"{jldir}/bin/condor_vault_storer -v"'
-    )
-    cmd = f"_condor_SEC_CREDENTIAL_STORER={_sec_cred_storer_val} {cmd}"
+
+    _sec_cred_storer_val = os.environ.get("_condor_SEC_CREDENTIAL_STORER", None)
+    if _sec_cred_storer_val is None:
+        _sec_cred_storer_val = (
+            f"{jldir}/bin/condor_vault_storer"
+            if not vargs.get("verbose")
+            else f"{jldir}/bin/condor_vault_storer -v"
+        )
+    cmd = f'_condor_SEC_CREDENTIAL_STORER="{_sec_cred_storer_val}" {cmd}'
 
     packages.orig_env()
     verbose = int(vargs.get("verbose", 0))

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -3,6 +3,7 @@ pools:
     Info about what condor pools we know about.  However we don't actually store the info here,
     we just parse it out of the environment.
 """
+
 # pylint: disable=global-statement, global-variable-not-assigned
 import argparse
 import json
@@ -33,6 +34,7 @@ def set_pool(name: str) -> None:
         raise KeyError(
             f"--global-pool value must be one of ({', '.join(poolmap.keys())})"
         )
+    packages.SAVED_ENV = os.environ.copy()  # Build on top of the old environment
     os.environ["_condor_COLLECTOR_HOST"] = poolmap[name]["collector"]
     packages.SAVED_ENV["_condor_COLLECTOR_HOST"] = poolmap[name]["collector"]
     if not SAVE_COLLECTOR_HOST:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+import pytest
+
+# we assume everwhere our current directory is in the package
+# test area, so go ahead and cd there
+#
+os.chdir(os.path.dirname(__file__))
+
+
+#
+# import modules we need to test, since we chdir()ed, can use relative path
+# unless we're testing installed, then use /opt/jobsub_lite/...
+#
+if os.environ.get("JOBSUB_TEST_INSTALLED", "0") == "1":
+    sys.path.append("/opt/jobsub_lite/lib")
+else:
+    sys.path.append("../lib")
+
+import condor
+import importlib
+import packages
+import pool
+import utils
+
+
+@pytest.mark.unit
+def test_set_pool(monkeypatch):
+    # TODO This needs to have a few more test cases, but this will do for now
+    monkeypatch.setenv(
+        "JOBSUB_POOL_MAP",
+        '{"global-pool-one": {"collector":"hostname.domain","onsite":"MY_ONSITE"}}',
+    )
+    monkeypatch.setenv("RANDOM_ENV", "RANDOM_VALUE")
+    importlib.reload(pool)
+    pool.set_pool("global-pool-one")
+    assert packages.SAVED_ENV["RANDOM_ENV"] == "RANDOM_VALUE"
+    assert packages.SAVED_ENV["_condor_COLLECTOR_HOST"] == "hostname.domain"
+    assert condor.COLLECTOR_HOST == "hostname.domain"
+    assert utils.ONSITE_SITE_NAME == "MY_ONSITE"
+    pool.reset_pool()


### PR DESCRIPTION
This fixes the bug brought up in the discussions offline.

It also allows us to pass verbose mode to the underlying condor_vault_storer call made by condor_submit, either through the environment or via the verbose flag.

I ran all the unit and integration tests to validate these changes.