### PR TITLE
This fixes a bug introduced in jobsub_lite 1.7

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -296,13 +296,17 @@ def submit(
     #
     jldir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    _sec_cred_storer_val = os.environ.get("_condor_SEC_CREDENTIAL_STORER", None)
-    if _sec_cred_storer_val is None:
-        _sec_cred_storer_val = (
-            f"{jldir}/bin/condor_vault_storer"
-            if not vargs.get("verbose")
-            else f"{jldir}/bin/condor_vault_storer -v"
-        )
+    # Set the _condor_SEC_CREDENTIAL_STORER environment variable to the path of the
+    # correct vault token storer script
+    # In the condor_vault_storer output, debug gives us more output than verbose,
+    # so make that mapping from our verbose/output to condor_vault_storer's
+    _sec_cred_storer_val = f"{jldir}/bin/condor_vault_storer"
+    if vargs.get("verbose", 0) == 1:
+        # Verbose
+        _sec_cred_storer_val = f"{_sec_cred_storer_val} -v"
+    elif vargs.get("verbose", 0) > 1:
+        # Debug
+        _sec_cred_storer_val = f"{_sec_cred_storer_val} -d"
     cmd = f'_condor_SEC_CREDENTIAL_STORER="{_sec_cred_storer_val}" {cmd}'
 
     packages.orig_env()

--- a/tests/test_condor_unit.py
+++ b/tests/test_condor_unit.py
@@ -1,4 +1,5 @@
 # pylint: disable=line-too-long
+import copy
 import os
 import sys
 import pytest
@@ -168,6 +169,33 @@ class TestCondorUnit:
         res = condor.submit(get_submit_file, TestUnit.test_vargs, TestUnit.test_schedd)
         print("got: ", res)
         assert res
+
+    @pytest.mark.unit
+    def test_submit_sec_cred_storer_predefined(
+        self, get_submit_file, needs_credentials, capsys, monkeypatch
+    ):
+        """actually submit a job with condor_submit"""
+        """Make sure that if we have _condor_SEC_CREDENTIAL_STORER defined before we run
+        condor_submit, we coerce it to the correct value.  This is how all POMS submissions expect
+        to operate"""
+        monkeypatch.setenv("_condor_SEC_CREDENTIAL_STORER", "/bin/true")
+        vargs = copy.deepcopy(TestUnit.test_vargs)
+        vargs["verbose"] = 1
+        res = condor.submit(get_submit_file, vargs, TestUnit.test_schedd)
+        print("got: ", res)
+        assert res  # Did submission succeed?
+
+        jl_condor_vault_storer_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "bin", "condor_vault_storer"
+        )
+        captured = capsys.readouterr()
+        # Make sure our submission used the correct _condor_SEC_CREDENTIAL_STORER
+        assert (
+            f'_condor_SEC_CREDENTIAL_STORER="{jl_condor_vault_storer_path} -v"'
+            in captured.out
+        )
+        # ...but that the overall environment was unchanged
+        assert os.getenv("_condor_SEC_CREDENTIAL_STORER") == "/bin/true"
 
     @pytest.mark.unit
     def test_submit_too_many_procs(self, get_submit_file, needs_credentials, capsys):


### PR DESCRIPTION
In #551, we changed the behavior of how the `_condor_SEC_CREDENTIAL_STORER` environment variable was used.  Previously, the `condor.py:submit()` function would always coerce that environment variable to point to the jobsub_lite version of `condor_vault_storer`.  #551 changed that so that if `_condor_SEC_CREDENTIAL_STORER` was defined prior to submission, that setting was respected.  This broke POMS submissions, as POMS relies on jobsub's overriding whatever setting for `_condor_SEC_CREDENTIAL_STORER` that exists.

Originally, that portion of #551 was put in place to allow us to pass verbose and debug to the underlying `condor_vault_storer` commands for troubleshooting purposes.  This PR keeps that behavior by using the user-passed `--verbose/--debug` flags while restoring the previous overriding of `_condor_SEC_CREDENTIAL_STORER`.

I also added tests to make sure we didn't accidentally re-break this behavior in the future.