### PR TITLE
Stealing token compat from ifdh.cfg for fake_ifdh.py

### DIFF
--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -385,9 +385,7 @@ def getProxy(
 
 
 # pylint: disable=invalid-name
-gfal_clean_env = (
-    "unset PYTHONHOME PYTHONPATH LD_LIBRARY_PATH GFAL_PLUGIN_DIR GFAL_CONFIG_DIR"
-)
+gfal_clean_env = "unset PYTHONHOME PYTHONPATH LD_LIBRARY_PATH GFAL_PLUGIN_DIR GFAL_CONFIG_DIR;  [ -s ${BEARER_TOKEN_FILE:-/dev/null} ] && export BEARER_TOKEN=`cat ${BEARER_TOKEN_FILE}`"
 
 
 def fix_pnfs(path: str) -> str:


### PR DESCRIPTION
Token-only launches were failing to copy sandbox files at launch... Needed 
BEARER_TOKEN set in the environment for gfal utilities.  Fixes #561 