### PR TITLE
Delete test file if it's already there (for example if a previous test run didn't finish unlinking the file

### DIFF
--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -399,6 +399,8 @@ class TestGetProxy:
 @pytest.mark.unit
 def test_cp():
     dest = __file__ + ".copy"
+    if os.path.exists(dest):
+        os.unlink(dest)
     fake_ifdh.cp(__file__, dest)
     assert os.path.exists(dest)
     os.unlink(dest)


### PR DESCRIPTION
Little testing bug I ran into when testing 1.8-rc1.