### PR TITLE
When --global-pool flag is passed, make sure we save the BEARER_TOKEN_FILE and X509_USER_PROXY into the restored environment post-submission

### DIFF
--- a/lib/creds.py
+++ b/lib/creds.py
@@ -18,6 +18,7 @@ import os
 from typing import Any, Dict, Optional, List
 
 import fake_ifdh
+import packages
 from tracing import as_span
 
 
@@ -53,6 +54,12 @@ class CredentialSet:
             environ_key = getattr(self, self_key, None)
             if environ_key:
                 os.environ[environ_key] = cred_path
+                # This needs to be added so that any credential we set stays in both the environment
+                # modified before get_creds() is called (such as the POMS pkg_find case) and the
+                # environment in which this function is called.  So far, that seems to only be the case
+                # for submissions that use the poms_client, so when that is moved to POMS, this can be removed.
+                packages.SAVED_ENV[environ_key] = cred_path
+                print(f"Set {environ_key} to {cred_path}")
 
 
 SUPPORTED_AUTH_METHODS = list(

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -59,7 +59,6 @@ class CredentialSet:
                 # environment in which this function is called.  So far, that seems to only be the case
                 # for submissions that use the poms_client, so when that is moved to POMS, this can be removed.
                 packages.SAVED_ENV[environ_key] = cred_path
-                print(f"Set {environ_key} to {cred_path}")
 
 
 SUPPORTED_AUTH_METHODS = list(

--- a/lib/creds.py
+++ b/lib/creds.py
@@ -58,7 +58,7 @@ class CredentialSet:
                 # modified before get_creds() is called (such as the POMS pkg_find case) and the
                 # environment in which this function is called.  So far, that seems to only be the case
                 # for submissions that use the poms_client, so when that is moved to POMS, this can be removed.
-                packages.SAVED_ENV[environ_key] = cred_path
+                packages.add_to_SAVED_ENV_if_not_empty(environ_key, cred_path)
 
 
 SUPPORTED_AUTH_METHODS = list(

--- a/lib/packages.py
+++ b/lib/packages.py
@@ -32,6 +32,14 @@ def orig_env() -> None:
         os.environ.update(SAVED_ENV)
 
 
+def add_to_SAVED_ENV_if_not_empty(key: str, value: str) -> None:
+    """Add environment variable to SAVED_ENV, checking
+    first if SAVED_ENV is populated.  We only want to add
+    anything to SAVED_ENV if it's already populated"""
+    if SAVED_ENV:
+        SAVED_ENV[key] = value
+
+
 def pkg_find(p: str, qual: str = "") -> None:
     """
     Use Spack or UPS to find the package mentioned and stuff its

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -36,7 +36,9 @@ def set_pool(name: str) -> None:
         )
     packages.SAVED_ENV = os.environ.copy()  # Build on top of the old environment
     os.environ["_condor_COLLECTOR_HOST"] = poolmap[name]["collector"]
-    packages.SAVED_ENV["_condor_COLLECTOR_HOST"] = poolmap[name]["collector"]
+    packages.add_to_SAVED_ENV_if_not_empty(
+        "_condor_COLLECTOR_HOST", poolmap[name]["collector"]
+    )
     if not SAVE_COLLECTOR_HOST:
         SAVE_COLLECTOR_HOST = condor.COLLECTOR_HOST
         SAVE_ONSITE_SITE_NAME = utils.ONSITE_SITE_NAME

--- a/lib/token_mods.py
+++ b/lib/token_mods.py
@@ -56,7 +56,7 @@ def use_token_copy(tokenfile: str) -> str:
     # modified before use_token_copy() is called (such as the POMS pkg_find case) and the
     # environment in which this function is called.  So far, that seems to only be the case
     # for submissions that use the poms_client, so when that is moved to POMS, this can be removed.
-    packages.SAVED_ENV["BEARER_TOKEN_FILE"] = copyto
+    packages.add_to_SAVED_ENV_if_not_empty("BEARER_TOKEN_FILE", copyto)
     return copyto
 
 

--- a/lib/token_mods.py
+++ b/lib/token_mods.py
@@ -12,6 +12,7 @@ import sys
 from typing import List, Set
 
 import scitokens  # type: ignore # pylint: disable=import-error
+import packages
 
 
 def get_job_scopes(
@@ -51,6 +52,11 @@ def use_token_copy(tokenfile: str) -> str:
     copyto = f"{tokenfile}.{pid}"
     shutil.copy(tokenfile, copyto)
     os.environ["BEARER_TOKEN_FILE"] = copyto
+    # This needs to be added so that any credential we set stays in both the environment
+    # modified before use_token_copy() is called (such as the POMS pkg_find case) and the
+    # environment in which this function is called.  So far, that seems to only be the case
+    # for submissions that use the poms_client, so when that is moved to POMS, this can be removed.
+    packages.SAVED_ENV["BEARER_TOKEN_FILE"] = copyto
     return copyto
 
 

--- a/tests/test_packages_unit.py
+++ b/tests/test_packages_unit.py
@@ -94,3 +94,20 @@ class TestPackagesUnit:
         env2 = os.environ.copy()
         # should have put the environment back
         assert env1 != env2
+
+
+@pytest.mark.unit
+def test_add_to_SAVED_ENV_if_not_empty():
+    """This test tests the add_to_SAVED_ENV_if_not_empty function, which governs access to packages.SAVED_ENV"""
+    # Test when SAVED_ENV is empty
+    packages.SAVED_ENV = {}
+    packages.add_to_SAVED_ENV_if_not_empty("key", "value")
+    assert packages.SAVED_ENV == {}
+
+    # Test when SAVED_ENV is not empty
+    packages.SAVED_ENV = {"existing_key": "existing_value"}
+    packages.add_to_SAVED_ENV_if_not_empty("new_key", "new_value")
+    assert packages.SAVED_ENV == {
+        "existing_key": "existing_value",
+        "new_key": "new_value",
+    }


### PR DESCRIPTION
This fixes a bug that was introduced with the combination of #565 and #551.  Namely, for the `--global-pool` case, we were saving the environment before modifying the collector host, and then directly before submission, restoring it with `packages.orig_env()`.  

In this bug, since the original environment is saved during argument parsing, the credentials have not yet been gotten, and thus the `BEARER_TOKEN_FILE` and `X509_USER_PROXY` environment settings were wiped when `packages.orig_env()` is called in `condor.submit()`.

This PR fixes that bug, revealed in the testing of the 1.8-rc1 release.