### PR TITLE
If cigetcert fails for any reason, raise `PermissionError`

### DIFF
--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -378,38 +378,39 @@ class TestGetToken:
 
 class TestGetProxy:
     @pytest.mark.unit
-    def test_getProxy_good(check_user_kerberos_creds, clear_token, set_group_fermilab):
+    def test_getProxy_good(
+        self, check_user_kerberos_creds, clear_token, set_group_fermilab
+    ):
         proxy = fake_ifdh.getProxy("Analysis")
         assert os.path.exists(proxy)
 
     @pytest.mark.unit
     def test_getProxy_override(
+        self,
         check_user_kerberos_creds,
         clear_x509_user_proxy,
         clear_token,
         set_group_fermilab,
+        fake_proxy_path,
         monkeypatch,
         tmp_path,
     ):
-        fake_path = tmp_path / "test_proxy"
+        fake_path = fake_proxy_path
         monkeypatch.setenv("X509_USER_PROXY", str(fake_path))
         proxy = fake_ifdh.getProxy("Analysis")
         assert proxy == str(fake_path)
 
     @pytest.mark.unit
     def test_getProxy_fail(
+        self,
         check_user_kerberos_creds,
         clear_x509_user_proxy,
         clear_token,
+        fake_proxy_path,
         monkeypatch,
         tmp_path,
     ):
-        fake_path = tmp_path / "test_proxy"
-        if os.path.exists(fake_path):
-            try:
-                os.unlink(fake_path)
-            except:
-                pass
+        fake_path = fake_proxy_path
         monkeypatch.setenv("X509_USER_PROXY", str(fake_path))
         monkeypatch.setenv("GROUP", "bozo")
         with pytest.raises(PermissionError):


### PR DESCRIPTION
Fixes #570.

This PR also adds two new unit tests to check the new logic, as well as a minor bug fix for the existing getProxy tests themselves.

Note:  According to the docs:

- https://docs.python.org/3.7/library/subprocess.html#subprocess.run
- https://docs.python.org/3.7/library/subprocess.html#subprocess.CompletedProcess.check_returncode

there are two ways to check if a `subprocess.run()` call fails:

1.  Pass the `check=True` kwarg to the function, which will make it raise a `CalledProcessError` if the return code of the underlying subprocess is nonzero (i.e. `subprocess.run('exit 1', check=True)` will raise a `CalledProcessError`), and
2. If you don't want to immediately raise the error, set `check=False`, and then save the return value of `subprocess.run()` to a variable (e.g. `result`).  Then, when you're ready, you can run `result.check_returncode()`, which will raise the `CalledProcessError` if the return code is nonzero.

We use the second method here, since we want to raise different errors based on the output of `cigetcert`.

