### PR TITLE
Add support for non-Analysis users in jobsub_cleanup_cred

### DIFF
--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -77,7 +77,9 @@ def query_creds(schedd: str) -> List[str]:
     line_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
     creds: Set[str] = set()
 
+    old_credd_host_setting = os.environ.get("_condor_CREDD_HOST")
     os.environ["_condor_CREDD_HOST"] = schedd
+
     cmd = "condor_store_cred query-oauth"
     print(f"credentials on {schedd}:")
     with os.popen(cmd) as scf:
@@ -88,6 +90,11 @@ def query_creds(schedd: str) -> List[str]:
                 print(line)
                 token_name = m.group(1)
                 creds.add(token_name)
+
+    # Make sure we set the env back before we return
+    if old_credd_host_setting is not None:
+        os.environ["_condor_CREDD_HOST"] = old_credd_host_setting
+
     return list(creds)
 
 

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -125,6 +125,9 @@ def del_cred(schedd, token_name, no_delete=False):
 
 def main():
     parser = get_parser.get_jobid_parser(add_condor_epilog=True)
+    parser.add_argument(
+        "--force", help="Force deletion", default=False, action="store_true"
+    )
     parser.add_argument("-name", help="Set schedd name", default=None)
     parser.add_argument(
         "-n",
@@ -137,13 +140,22 @@ def main():
     varg = vars(args)
     nflag = args.no_delete
 
-    cs = get_creds(varg)  # pylint: disable=unused-variable
+    get_creds(varg)  # pylint: disable=unused-variable
     schedd_list = get_schedd_names(varg)
     if args.name and args.name not in schedd_list:
         print(f"invalid schedd {args.name}")
         sys.exit(1)
     if args.name and args.name in schedd_list:
         schedd_list = [args.name]
+
+    if not nflag and not args.force:
+        response = input(
+            f"This will delete all of your tokens on the following schedds: {', '.join(schedd_list)}.\nAre you sure you want to proceed (Y/n)? "
+        )
+        if response != "Y":
+            print("Not deleting tokens.")
+            sys.exit(0)
+
     print(f"Schedds to clean: {schedd_list}")
     for schedd_host in schedd_list:
         for tname in query_creds(schedd_host):

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -75,8 +75,8 @@ mu2e_production_3217a16627.use = 1727294085
 def query_creds(schedd) -> List[str]:
     # For a line that matches the pattern, extract everything before the '.top|.use'
     line_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
-
     creds: Set[str] = set()
+
     os.environ["_condor_CREDD_HOST"] = schedd
     cmd = "condor_store_cred query-oauth"
     print(f"credentials on {schedd}:")
@@ -91,23 +91,34 @@ def query_creds(schedd) -> List[str]:
     return list(creds)
 
 
-# TODO:  Parse out name and handle using regex
 def del_cred(schedd, token_name, no_delete=False):
     os.environ["_condor_CREDD_HOST"] = schedd
+    args: List[str] = []
 
-    # Token names are in the form "service_handle", where service can be just "experiment" or
-    # "experiment_role".  So we need to allow for these cases:
-    # 1. experiment_handle
-    # 2. experiment_role_handle
-    # 3. experiment
-    if token_name.find("_") > 0:
-        token_name, handle = token_name.split("_")
-        # TODO Here we need to account for token_name_handle or token_name_role_handle
-        cmd = f"condor_store_cred delete-oauth -s {token_name} -H {handle}"
+    # Token names can be:
+    # 1. experiment
+    # 2. experiment_handle
+    # 3. experiment_role_handle
+    token_name_parts = token_name.rsplit("_", maxsplit=1)
+    if len(token_name_parts) == 1:
+        # 1. experiment
+        service = token_name
+        args = ["-s", service]
+    elif len(token_name_parts) == 2:
+        # 2. experiment_handle or 3. experiment_role_handle
+        service, handle = token_name_parts
+        args = ["-s", service, "-H", handle]
     else:
-        cmd = f"condor_store_cred delete-oauth -s {token_name}"
+        print(f"Invalid credential name: {token_name}. Not deleting credentials")
+        return
+
+    args_string = " ".join(args)
+    cmd = f"condor_store_cred delete-oauth {args_string}"
+
     act = "I would run: " if no_delete else "Running:"
+    # Note: _condor_CREDD_HOST is already set in the environment, but this output is for the user to see which schedd was used
     print(f"{act} _condor_CREDD_HOST={schedd} {cmd}")
+
     if not no_delete:
         os.system(cmd)
 

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -24,6 +24,8 @@
 
 import os
 import re
+import shlex
+import subprocess
 import sys
 from typing import List, Set
 
@@ -99,7 +101,9 @@ def query_creds(schedd: str) -> List[str]:
 
 
 def del_cred(schedd: str, token_name: str, no_delete: bool = False) -> None:
+    old_credd_host_setting = os.environ.get("_condor_CREDD_HOST")
     os.environ["_condor_CREDD_HOST"] = schedd
+
     args: List[str] = []
 
     # Token names can be:
@@ -116,18 +120,38 @@ def del_cred(schedd: str, token_name: str, no_delete: bool = False) -> None:
         service, handle = token_name_parts
         args = ["-s", service, "-H", handle]
     else:
-        print(f"Invalid credential name: {token_name}. Not deleting credentials")
+        print(
+            f"Invalid credential name: {token_name}. Not deleting credentials from {schedd}"
+        )
         return
 
-    args_string = " ".join(args)
-    cmd = f"condor_store_cred delete-oauth {args_string}"
+    cmd = f"condor_store_cred delete-oauth {' '.join(args)}"
 
     act = "I would run: " if no_delete else "Running:"
     # _condor_CREDD_HOST is already set in the environment, but this output is for the user to see which schedd was used
     print(f"{act} _condor_CREDD_HOST={schedd} {cmd}")
 
     if not no_delete:
-        os.system(cmd)
+        try:
+            proc = subprocess.run(
+                shlex.split(cmd),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                encoding="UTF-8",
+                env=os.environ,
+            )
+            print(proc.stdout)
+        except subprocess.CalledProcessError as e:
+            print(f"Attempt to delete credential failed: {e}")
+            raise e
+        except Exception as e:
+            print(f"Unknown error deleting credential: {e}")
+            raise e
+        finally:
+            # Make sure we set the env back before we either return or reraise the exception
+            if old_credd_host_setting is not None:
+                os.environ["_condor_CREDD_HOST"] = old_credd_host_setting
 
 
 def main():
@@ -164,12 +188,27 @@ def main():
             sys.exit(0)
 
     print(f"Schedds to clean: {schedd_list}")
+    failed = False
     for schedd_host in schedd_list:
         for tname in query_creds(schedd_host):
-            del_cred(schedd_host, tname, nflag)
+            try:
+                del_cred(schedd_host, tname, nflag)
+            except subprocess.CalledProcessError:
+                print("Will try to delete the next credential.")
+                failed = True
+            except Exception:  # pylint: disable=broad-except
+                print("Unknown error deleting credential.  Will stop here.")
+                failed = True
+                break
+
     print("After:")
     for schedd_host in schedd_list:
         query_creds(schedd_host)
+
+    if failed:
+        print("Done, with some failures.")
+        sys.exit(1)
+
     print("Done.")
 
 

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -89,7 +89,7 @@ def query_creds(schedd: str) -> List[str]:
             line = line.strip()
             m = credential_infoline_regex.fullmatch(line)
             if m is not None:
-                print(line)
+                print(f"\t{line}")
                 token_name = m.group(1)
                 creds.add(token_name)
 
@@ -129,29 +129,30 @@ def del_cred(schedd: str, token_name: str, no_delete: bool = False) -> None:
 
     act = "I would run: " if no_delete else "Running:"
     # _condor_CREDD_HOST is already set in the environment, but this output is for the user to see which schedd was used
-    print(f"{act} _condor_CREDD_HOST={schedd} {cmd}")
+    print(f"{act} _condor_CREDD_HOST={schedd} {cmd}\n")
+    if no_delete:
+        return
 
-    if not no_delete:
-        try:
-            proc = subprocess.run(
-                shlex.split(cmd),
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                encoding="UTF-8",
-                env=os.environ,
-            )
-            print(proc.stdout)
-        except subprocess.CalledProcessError as e:
-            print(f"Attempt to delete credential failed: {e}")
-            raise e
-        except Exception as e:
-            print(f"Unknown error deleting credential: {e}")
-            raise e
-        finally:
-            # Make sure we set the env back before we either return or reraise the exception
-            if old_credd_host_setting is not None:
-                os.environ["_condor_CREDD_HOST"] = old_credd_host_setting
+    try:
+        proc = subprocess.run(
+            shlex.split(cmd),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="UTF-8",
+            env=os.environ,
+        )
+        print(proc.stdout)
+    except subprocess.CalledProcessError as exc:
+        print(f"Attempt to delete credential failed: {exc}")
+        raise exc
+    except Exception as exc:
+        print(f"Unknown error deleting credential: {exc}")
+        raise exc
+    finally:
+        # Make sure we set the env back before we either return or reraise the exception
+        if old_credd_host_setting is not None:
+            os.environ["_condor_CREDD_HOST"] = old_credd_host_setting
 
 
 def main():
@@ -181,7 +182,7 @@ def main():
 
     if not nflag and not args.force:
         response = input(
-            f"This will delete all of your tokens on the following schedds: {', '.join(schedd_list)}.\nAre you sure you want to proceed (Y/n)? "
+            f"This will delete all of your tokens on the following schedds: {', '.join(schedd_list)}.\nAre you sure you want to proceed (Y/[n])? "
         )
         if response != "Y":
             print("Not deleting tokens.")
@@ -201,16 +202,24 @@ def main():
                 failed = True
                 break
 
+    if nflag:
+        print("\n--no-delete was specified, so no credentials were deleted. Done.")
+        return
+
     print("After:")
     for schedd_host in schedd_list:
         query_creds(schedd_host)
 
     if failed:
         print("Done, with some failures.")
-        sys.exit(1)
+        raise Exception("Some credentials failed to delete.")
 
     print("Done.")
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:  # pylint: disable=broad-except
+        sys.stderr.write(f"\n\nError: {e.__class__.__name__}: {str(e)}\n\n")
+        sys.exit(1)

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -72,11 +72,11 @@ mu2e_production_2a9433c222.use = 1727293453
 mu2e_production_3217a16627.top = 1714234004
 mu2e_production_3217a16627.use = 1727294085
 """
+credential_infoline_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
 
 
 def query_creds(schedd: str) -> List[str]:
     # For a line that matches the pattern, extract everything before the '.top|.use'
-    line_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
     creds: Set[str] = set()
 
     old_credd_host_setting = os.environ.get("_condor_CREDD_HOST")
@@ -87,7 +87,7 @@ def query_creds(schedd: str) -> List[str]:
     with os.popen(cmd) as scf:
         for line in scf.readlines():
             line = line.strip()
-            m = line_regex.fullmatch(line)
+            m = credential_infoline_regex.fullmatch(line)
             if m is not None:
                 print(line)
                 token_name = m.group(1)

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -23,8 +23,9 @@
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 
 import os
+import re
 import sys
-from typing import List
+from typing import List, Set
 
 if os.environ.get("LD_LIBRARY_PATH", ""):
     del os.environ["LD_LIBRARY_PATH"]
@@ -56,40 +57,55 @@ dune_ab0f4c39c0.use = 1682976330
 and:
 BEARER_TOKEN_FILE=/tmp/bt_token... _condor_COLLECTOR_HOST=xxx _condor_CREDD_HOST=yyy condor_store_cred delete-oauth -s credname
 will delete the one named 'credname' (i.e. either 'dune' or 'dune_ab0f4c39c0' in my example above).
+
+We need to also support non-Analysis role credentials, which will look like this:
+mu2e_production.top = 1727117911
+mu2e_production.use = 1727293653
+mu2e_production_03c3eee999.top = 1714853842
+mu2e_production_03c3eee999.use = 1727294084
+mu2e_production_23a032e37b.top = 1720436436
+mu2e_production_23a032e37b.use = 1727294082
+mu2e_production_2a9433c222.top = 1724808389
+mu2e_production_2a9433c222.use = 1727293453
+mu2e_production_3217a16627.top = 1714234004
+mu2e_production_3217a16627.use = 1727294085
 """
 
 
-def query_creds(schedd):
-    res: List[str] = []
+def query_creds(schedd) -> List[str]:
+    # For a line that matches the pattern, extract everything before the '.top|.use'
+    line_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
+
+    creds: Set[str] = set()
     os.environ["_condor_CREDD_HOST"] = schedd
-    parsing = False
     cmd = "condor_store_cred query-oauth"
-    last_tname = "xx"
     print(f"credentials on {schedd}:")
     with os.popen(cmd) as scf:
         for line in scf.readlines():
             line = line.strip()
-            if line == "Credential info:":
-                parsing = True
-                continue
-            if line and parsing:
+            m = line_regex.fullmatch(line)
+            if m is not None:
                 print(line)
-                tname, time = line.split("=")
-                tname = tname.strip().replace(".top", "").replace(".use", "")
-                time = time.strip()
-                if tname != last_tname:
-                    res.append(tname)
-                last_tname = tname
-    return res
+                token_name = m.group(1)
+                creds.add(token_name)
+    return list(creds)
 
 
-def del_cred(schedd, tname, no_delete=False):
+# TODO:  Parse out name and handle using regex
+def del_cred(schedd, token_name, no_delete=False):
     os.environ["_condor_CREDD_HOST"] = schedd
-    if tname.find("_") > 0:
-        tname, handle = tname.split("_")
-        cmd = f"condor_store_cred delete-oauth -s {tname} -H {handle}"
+
+    # Token names are in the form "service_handle", where service can be just "experiment" or
+    # "experiment_role".  So we need to allow for these cases:
+    # 1. experiment_handle
+    # 2. experiment_role_handle
+    # 3. experiment
+    if token_name.find("_") > 0:
+        token_name, handle = token_name.split("_")
+        # TODO Here we need to account for token_name_handle or token_name_role_handle
+        cmd = f"condor_store_cred delete-oauth -s {token_name} -H {handle}"
     else:
-        cmd = f"condor_store_cred delete-oauth -s {tname}"
+        cmd = f"condor_store_cred delete-oauth -s {token_name}"
     act = "I would run: " if no_delete else "Running:"
     print(f"{act} _condor_CREDD_HOST={schedd} {cmd}")
     if not no_delete:

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -72,7 +72,7 @@ mu2e_production_3217a16627.use = 1727294085
 """
 
 
-def query_creds(schedd) -> List[str]:
+def query_creds(schedd: str) -> List[str]:
     # For a line that matches the pattern, extract everything before the '.top|.use'
     line_regex = re.compile(r"^([A-Za-z0-9_]+)\.(?:top|use)\s=\s[0-9]+$")
     creds: Set[str] = set()
@@ -91,7 +91,7 @@ def query_creds(schedd) -> List[str]:
     return list(creds)
 
 
-def del_cred(schedd, token_name, no_delete=False):
+def del_cred(schedd: str, token_name: str, no_delete: bool = False) -> None:
     os.environ["_condor_CREDD_HOST"] = schedd
     args: List[str] = []
 
@@ -116,7 +116,7 @@ def del_cred(schedd, token_name, no_delete=False):
     cmd = f"condor_store_cred delete-oauth {args_string}"
 
     act = "I would run: " if no_delete else "Running:"
-    # Note: _condor_CREDD_HOST is already set in the environment, but this output is for the user to see which schedd was used
+    # _condor_CREDD_HOST is already set in the environment, but this output is for the user to see which schedd was used
     print(f"{act} _condor_CREDD_HOST={schedd} {cmd}")
 
     if not no_delete:

--- a/bin/jobsub_cleanup_cred
+++ b/bin/jobsub_cleanup_cred
@@ -155,7 +155,7 @@ def del_cred(schedd: str, token_name: str, no_delete: bool = False) -> None:
 
 
 def main():
-    parser = get_parser.get_jobid_parser(add_condor_epilog=True)
+    parser = get_parser.get_jobid_parser(add_condor_epilog=False)
     parser.add_argument(
         "--force", help="Force deletion", default=False, action="store_true"
     )


### PR DESCRIPTION
Closes #549 

This PR cleans up a lot of the code in `jobsub_cleanup_cred`.  The main changes are:

1. Adding support for non-Analysis roles, 
2. Adding error handling to the executable
3. Added a confirmation check before a user deletes credentials 