### PR TITLE
Upgraded test container image from 9.3-minimal to 9.4-minimal

### DIFF
--- a/.github/workflows/build-al9-push.yaml
+++ b/.github/workflows/build-al9-push.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Build master after push in AL9 container"
     container:
-      image: almalinux:9.3-minimal
+      image: almalinux:9.4-minimal
     steps:
       - name: Install tar and gzip
         run: |


### PR DESCRIPTION
There are many security vulnerabilities in the AlmaLinux 9.3-minimal image (see https://hub.docker.com/layers/library/almalinux/9.3-minimal/images/sha256-16467e6b56cbd2e1f6621b2778003145e619fdbb8c5fed0dbfac851498d3719c?context=explore).  

This upgrades the workflow container to AlmaLinux 9.4.