### PR TITLE
Fix RUNTIME for running jobs

### DIFF
--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -206,11 +206,12 @@ def main() -> None:
                     "%-11s ",
                     'formatTime(QDate,"%m/%d %H:%M")',
                     "-format",  # RUNTIME
-                    # For running jobs, use ServerTime - ShadowBday.  Otherwise, use RemoteWallClockTime
+                    # For running jobs, use ServerTime - ShadowBday, and add it to the accumulated RemoteWallClockTime for previous executions
+                    # of the job.  Otherwise, use RemoteWallClockTime
                     # This is because RemoteWallClockTime is only updated when jobs stop running - either through
                     # completion, removal, or being held.
                     "%T ",
-                    "IfThenElse(JobStatus == 2, ServerTime - ShadowBday, RemoteWallClockTime)",
+                    "IfThenElse(JobStatus == 2, (ServerTime - ShadowBday) + RemoteWallClockTime, RemoteWallClockTime)",
                     "-format",  # ST
                     " %s ",
                     'substr("UIRXCHE",JobStatus,1)',

--- a/bin/jobsub_cmd
+++ b/bin/jobsub_cmd
@@ -196,31 +196,34 @@ def main() -> None:
             # default to old jobsub format
             execargs.extend(
                 [
-                    "-format",
+                    "-format",  # JOBSUBJOBID
                     "%-40s",
                     'strcat(split(GlobalJobId,"#")[1],"@",split(GlobalJobId,"#")[0])',
-                    "-format",
+                    "-format",  # OWNER
                     "%-10s\t",
                     """(DAGNodeName=!=''?strcat(" |-",DAGNodeName):Owner)""",
-                    "-format",
+                    "-format",  # SUBMITTED
                     "%-11s ",
                     'formatTime(QDate,"%m/%d %H:%M")',
-                    "-format",
+                    "-format",  # RUNTIME
+                    # For running jobs, use ServerTime - ShadowBday.  Otherwise, use RemoteWallClockTime
+                    # This is because RemoteWallClockTime is only updated when jobs stop running - either through
+                    # completion, removal, or being held.
                     "%T ",
-                    "RemoteWallClockTime",
-                    "-format",
+                    "IfThenElse(JobStatus == 2, ServerTime - ShadowBday, RemoteWallClockTime)",
+                    "-format",  # ST
                     " %s ",
                     'substr("UIRXCHE",JobStatus,1)',
-                    "-format",
+                    "-format",  # PRIO
                     " %3d ",
                     "JobPrio",
-                    "-format",
+                    "-format",  # SIZE
                     "%6.1f ",
                     "ImageSize/1024.0",
-                    "-format",
+                    "-format",  # COMMAND
                     "%s",
                     "JobsubCmd=!=''?JobsubCmd:Cmd",
-                    "-format",
+                    "-format",  # arguments after COMMAND
                     " %-.20s",
                     "Args",
                     "-format",

--- a/bin/jobsub_totals
+++ b/bin/jobsub_totals
@@ -6,6 +6,9 @@ from collections import defaultdict, OrderedDict
 import re
 import sys
 
+# clusterid.procid@schedd_name  owner submitted runtime st <rest of line that we're ignoring for this regex>
+line_regex = re.compile(r"\d+\.\d+@\S+(\s+\S+){4}\s+([CXIRHS])")
+
 type_map = OrderedDict(
     [
         ("T", "total; "),
@@ -23,9 +26,9 @@ totals["T"] = 0
 
 for line in sys.stdin.readlines():
     print(line, end="")
-    m = re.match(r"\d+\.\d+@\S+(\s+\S+){4}\s+([CXIRHS])", line)
+    m = line_regex.match(line)
     if m:
-        totals[m.group(2)] += 1
+        totals[m.group(2)] += 1  # Increment the count for the type of job
         totals["T"] += 1
 
 for i in type_map:


### PR DESCRIPTION
Closes #501 

Sometime in the last few Condor releases, the classad `RemoteWallClockTime` stopped being populated in a job's classad while a job was running, and that broke our `jobsub_q`.  After consultation with the condor developers, this PR has the new implementation of calculating the job's cumulative run time.

The calculation for a running job is:  `(ServerTime - ShadowBday) + RemoteWallClockTime`.

For an idle, completed, or held job, the classad `RemoteWallClockTime` still works, and that's reflected in this PR.

This PR also includes a small tweak to the `jobsub_totals` script to improve performance; and a few comments to make clear what Condor expression corresponds to what column.
