### PR TITLE
Put line continuation backslash back into fife_wrap tests

### DIFF
--- a/tests/test_submit_wait_int.py
+++ b/tests/test_submit_wait_int.py
@@ -432,7 +432,7 @@ def fife_launch(extra):
           --memory=500MB  \
           %(extra)s \
           --dataset-definition=gen_cfg  \
-          file://///cvmfs/fermilab.opensciencegrid.org/products/common/db/../prd/fife_utils/v3_3_2/NULL/libexec/fife_wrap
+          file://///cvmfs/fermilab.opensciencegrid.org/products/common/db/../prd/fife_utils/v3_3_2/NULL/libexec/fife_wrap \
             --find_setups \
             --setup-unquote 'hypotcode%%20v1_1' \
             --setup-unquote 'ifdhc%%20v2_6_10,ifdhc_config%%20v2_6_15' \


### PR DESCRIPTION
I accidentally broke the integration tests that depend on `fife_wrap` with #582.  This PR fixes that bug.