### PR TITLE
Add --gpu flag to submit jobs to GPU resources

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -305,7 +305,9 @@ def get_parser() -> argparse.ArgumentParser:
         default=os.environ.get("CMTCONFIG", ""),
         help=" Set up minervasoft release built with cmt configuration. default is $CMTCONFIG",
     )
-    parser.add_argument("--cpu", help="request worker nodes have at least NUMBER cpus")
+    parser.add_argument(
+        "--cpu", metavar="NUMBER", help="Request worker nodes have at least NUMBER cpus"
+    )
     parser.add_argument(
         "--dag",
         help="submit and run a dagNabbit input file",
@@ -412,6 +414,9 @@ def get_parser() -> argparse.ArgumentParser:
         default=False,
         help="generate and mail a summary report of completed/failed/removed"
         " jobs in a DAG",
+    )
+    parser.add_argument(
+        "--gpu", metavar="NUMBER", help="request worker nodes have at least NUMBER cpus"
     )
     parser.add_argument(
         "-L", "--log-file", "--log_file", help="Log file to hold log output from job."

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -28,7 +28,7 @@ when_to_transfer_output = ON_EXIT_OR_EVICT
 {%if    cpu is defined and cpu %}request_cpus = {{cpu}}{%endif%}
 {%if    gpu is defined and gpu %}
 request_GPUs = {{gpu}}
-RequestGPUs = {{gpu}}
++RequestGPUs = {{gpu}}
 {%endif%}
 {%if memory is defined and memory %}request_memory = {{memory}}{%endif%}
 {%if   disk is defined and disk %}request_disk = {{disk}}KB{%endif%}

--- a/templates/simple/simple.cmd
+++ b/templates/simple/simple.cmd
@@ -26,6 +26,10 @@ transfer_input_files = {{executable|basename}}
 transfer_output_files = .empty_file
 when_to_transfer_output = ON_EXIT_OR_EVICT
 {%if    cpu is defined and cpu %}request_cpus = {{cpu}}{%endif%}
+{%if    gpu is defined and gpu %}
+request_GPUs = {{gpu}}
+RequestGPUs = {{gpu}}
+{%endif%}
 {%if memory is defined and memory %}request_memory = {{memory}}{%endif%}
 {%if   disk is defined and disk %}request_disk = {{disk}}KB{%endif%}
 {%if     OS is defined and OS %}+DesiredOS="{{OS}}"{%endif%}

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -176,6 +176,8 @@ def all_test_args():
         "--generate-email-summary",
         "--global-pool",
         "dune",
+        "--gpu",
+        "xxgpuxx",
         "--group",
         "xxgroupxx",
         "--job-info",

--- a/tests/test_jobsub_submit_unit.py
+++ b/tests/test_jobsub_submit_unit.py
@@ -122,7 +122,7 @@ class TestJobsubSubmitUnit:
         """make sure --gpu NUMBER sets arguments it's supposed to"""
         # Test parameters
         num_gpus = 42
-        wanted_strings = ("request_GPUs = 42", "RequestGPUs = 42")
+        wanted_strings = ("request_GPUs = 42", "+RequestGPUs = 42")
 
         # Set up our temp test directories and copy the template file
         temp_prefix = (


### PR DESCRIPTION
Closes #505

This new flag sets the following classads in the generated Job Definition File:

* `request_GPUs`  (for HTCondor:  See https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#jobs-that-require-gpus)
* `RequestGPUs` (For the OSG/GlideinWMS.  This flag has been in use for Fermilab's GWMS Frontends, and seems to be an alternate convention for jobs running on the OSG).

All unit and integration tests pass with this PR. 