### PR TITLE
Break submit trace into two spans and add tracing to wrapper 

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -58,7 +58,7 @@ from submit_support import (
 )
 from tarfiles import do_tarballs
 from token_mods import get_job_scopes, use_token_copy
-from tracing import as_span, log_host_time
+from tracing import as_span, log_host_time, get_propagator_carrier
 from utils import (
     set_extras_n_fix_units,
     cleanup,
@@ -70,17 +70,9 @@ from version import print_version, print_support_email
 verbose = 0  # pylint: disable=invalid-name
 
 
-# pylint: disable=too-many-branches,too-many-statements
-@as_span("jobsub_submit", is_main=True)
+@as_span("jobsub", is_main=True)
 def main():
-    """script mainline:
-    - parse args
-    - get credentials
-    - handle tarfile options
-    - set added values from environment, etc.
-    - convert/render template files to submission files
-    - launch
-    """
+    """main entrypoint, handles basic arg parsing and creates parent span for submission"""
     global verbose  # pylint: disable=global-statement,invalid-name
     parser = get_parser()
 
@@ -104,8 +96,6 @@ def main():
 
     verbose = args.verbose
 
-    log_host_time(verbose)
-
     # if they were trying to pass LD_LIBRARY_PATH to the job, get it from HIDE_LD_LIBRARY_PATH
     if "LD_LIBRARY_PATH" in args.environment and os.environ.get(
         "HIDE_LD_LIBRARY_PATH", ""
@@ -114,6 +104,33 @@ def main():
             f"{x}={os.environ['HIDE_LD_LIBRARY_PATH']}" if x == "LD_LIBRARY_PATH" else x
             for x in args.environment
         ]
+
+    # get tracing propagator traceparent id so we can use it in templates, etc.
+    if args.traceparent is None:
+        carrier = get_propagator_carrier()
+        if carrier and "traceparent" in carrier:
+            args.traceparent = carrier["traceparent"]
+        else:
+            args.traceparent = ""
+
+        if verbose > 0:
+            sys.stderr.write(f"Setting traceparent: {args.traceparent}\n")
+
+    submit(args)
+
+
+# pylint: disable=too-many-branches,too-many-statements
+@as_span("jobsub_submit")
+def submit(args):
+    """script mainline:
+    - get credentials
+    - handle tarfile options
+    - set added values from environment, etc.
+    - convert/render template files to submission files
+    - launch
+    """
+
+    log_host_time(args.verbose)
 
     if args.version:
         print_version()

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -240,6 +240,11 @@ def get_base_parser(add_condor_epilog: bool = False) -> argparse.ArgumentParser:
         action=CheckIfValidSchedd,
         help=argparse.SUPPRESS,
     )
+    group.add_argument(
+        "--traceparent",
+        help="Trace context",
+        default=os.environ.get("TRACEPARENT", None),
+    )
     return parser
 
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -30,7 +30,6 @@ from typing import Union, Dict, Any, NamedTuple, Tuple, List, Optional
 import uuid
 
 import classad  # type: ignore # pylint: disable=import-error
-from tracing import get_propagator_carrier
 import token_mods
 
 from creds import CredentialSet
@@ -198,18 +197,6 @@ def set_extras_n_fix_units(
         sys.stderr.write(f"entering set_extras... args: {repr(args)}\n")
 
     set_some_extras(args, schedd_name, cred_set)
-
-    #
-    # get tracing propagator traceparent id so we can use it in templates, etc.
-    #
-    carrier = get_propagator_carrier()
-    if carrier and "traceparent" in carrier:
-        args["traceparent"] = carrier["traceparent"]
-    else:
-        args["traceparent"] = ""
-
-    if args["verbose"] > 0:
-        sys.stderr.write(f"Setting traceparent: {args['traceparent']}\n")
 
     # Read in credentials
     for cred_type, cred_path in vars(cred_set).items():


### PR DESCRIPTION
This breaks the initial trace into two spans: a `jobsub` overarching span and a `jobsub_submit` span that contains the submit steps. This way any subsequent spans are not shown as being part of the submit, and the submit span can be collapsed without hiding them. There's still a bit of discontinuity where the `jobsub` span ends with the submit and does not encapsulate downstream spans, but that would be tough to avoid and I don't think it causes any major issues, the trace otherwise appears OK in Jaeger.

Further, this roughly adds a tracing span to the job wrapper (only `simple.sh` for now). I anticipate some iteration here before merging and including in DAGs. Some key items:
* Span ID generation
* Environment variables for endpoints and options

![Screenshot 2024-12-11 at 12-23-02 Lightning talk distributed tracing - Google Slides](https://github.com/user-attachments/assets/858878a3-23b3-4295-84b2-ef26cd3b74e4)
![Screenshot 2024-12-11 at 12-23-12 Lightning talk distributed tracing - Google Slides](https://github.com/user-attachments/assets/7d4ca38a-e7b1-4024-bdd8-232db2891f14)
![Screenshot 2024-12-11 at 12-30-19 Lightning talk distributed tracing - Google Slides](https://github.com/user-attachments/assets/6e4f255b-5172-468d-828c-c59cce79b898)

