### PR TITLE
draft of implementing #596

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -320,7 +320,7 @@ def submit(
     # In the condor_vault_storer output, debug gives us more output than verbose,
     # so make that mapping from our verbose/output to condor_vault_storer's
 
-    if vargs["managed_tokens"] and ran_vault_storer_recently(
+    if vargs["managed_token"] and ran_vault_storer_recently(
         schedd_name, vargs["oauth_handle"], vargs["outbase"]
     ):
         _sec_cred_storer_val = "/bin/true"
@@ -386,7 +386,7 @@ def submit(
             return None
 
         if (
-            vargs["managed_tokens"]
+            vargs["managed_token"]
             and os.environ.get("_condor_SEC_CREDENTIAL_STORER", "unset") != "/bin/true"
         ):
             record_vault_storer_run(

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -266,6 +266,7 @@ def ran_vault_storer_recently(schedd: str, handle: str, outbase: str) -> bool:
     and it was within the last week minus a bit"""
     try:
         sv = os.stat(f"{outbase}/.cvs_{schedd}_{handle}")
+        # print(f"saw cvs file, sv.st_mtime is {sv.st_mtime} check: {sv.st_mtime > time.time() - 604500}")
         # 1 week: 24 * 7 * 60 * 60 = 604800, les 5 minutes (300) -> 604500
         return sv.st_mtime > time.time() - 604500
     except FileNotFoundError:
@@ -277,6 +278,7 @@ def record_vault_storer_run(schedd: str, handle: str, outbase: str) -> None:
     # recreate/touch the file
     with open(f"{outbase}/.cvs_{schedd}_{handle}", "w", encoding="utf-8"):
         pass
+    # print("wrote cvs file...")
 
 
 # pylint: disable=dangerous-default-value,too-many-locals,too-many-branches,too-many-statements
@@ -385,10 +387,7 @@ def submit(
             )
             return None
 
-        if (
-            vargs["managed_token"]
-            and os.environ.get("_condor_SEC_CREDENTIAL_STORER", "unset") != "/bin/true"
-        ):
+        if vargs["managed_token"] and _sec_cred_storer_val != "/bin/true":
             record_vault_storer_run(
                 schedd_name, vargs["oauth_handle"], vargs["outbase"]
             )

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -480,7 +480,7 @@ def get_parser() -> argparse.ArgumentParser:
         " this into account",
     )
     parser.add_argument(
-        "--manged-token",
+        "--managed-token",
         action="store_const",
         const=True,
         default=False,

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -484,7 +484,7 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_const",
         const=True,
         default=False,
-        help="Optimize calls to condor_vault_storer, etc.",
+        help="Optimize calls to condor_vault_storer, etc. when using managed tokens",
     )
     parser.add_argument(
         "--memory",

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -480,6 +480,13 @@ def get_parser() -> argparse.ArgumentParser:
         " this into account",
     )
     parser.add_argument(
+        "--manged-token",
+        action="store_const",
+        const=True,
+        default=False,
+        help="Optimize calls to condor_vault_storer, etc.",
+    )
+    parser.add_argument(
         "--memory",
         default="2GB",
         help="Request worker nodes have at least NUMBER[UNITS] of memory."


### PR DESCRIPTION
So this adds a --managed-token flag to jobsub_submit, which suppresses calling condor_vault_storer when we have
recently called it for this oauth_handle/token scope hash and this schedd. 
