### PR TITLE
Added env JOBSUB_MANAGED_TOKEN to control --managed-token flag default

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -483,8 +483,10 @@ def get_parser() -> argparse.ArgumentParser:
         "--managed-token",
         action="store_const",
         const=True,
-        default=False,
-        help="Optimize calls to condor_vault_storer, etc. when using managed tokens",
+        default=os.environ.get("JOBSUB_MANAGED_TOKEN", None) is not None,
+        help="Will attempt to bypass calling condor_vault_storer during job submission. "
+        "Assumes that vault token is managed externally, so condor_vault_storer will "
+        "only be called once every six days.",
     )
     parser.add_argument(
         "--memory",

--- a/man/man1/jobsub_submit.1
+++ b/man/man1/jobsub_submit.1
@@ -280,6 +280,10 @@ your job lands on runs all jobs in singularity
 containers, your job will also run in one. If the site
 does not run all jobs in singularity containers, your
 job will run outside a singularity container.
+.HP
+--managed-token       Will attempt to bypass calling condor_vault_storer during
+job submission. Assumes that vault token is managed externally, so
+condor_vault_storer will only be called once every six days.
 
 general arguments:
 .HP

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -190,6 +190,7 @@ def all_test_args():
         "--mail-never",
         "--mail-on-error",
         "--mail-always",
+        "--managed-token",
         "--maxConcurrent",
         "xxmaxConcurrentxx",
         "--memory",
@@ -647,3 +648,25 @@ class TestGetParserUnit:
         finally:
             if old_auth_methods_env_value:
                 os.environ["JOBSUB_AUTH_METHODS"] = old_auth_methods_env_value
+
+    @pytest.mark.unit
+    def test_managed_token_flag_env_set_clean_env(self, monkeypatch):
+        """Check that a clean environment does not have the managed token flag set
+        after parsing args"""
+        old_managed_token_env_value = os.environ.get("JOBSUB_MANAGED_TOKEN", None)
+        monkeypatch.delenv("JOBSUB_MANAGED_TOKEN", raising=False)
+        args = get_parser.get_parser().parse_args([])
+        try:
+            assert not args.managed_token
+        finally:
+            if old_managed_token_env_value:
+                os.environ["JOBSUB_MANAGED_TOKEN"] = old_managed_token_env_value
+
+    @pytest.mark.unit
+    def test_managed_token_flag_env_set(self, monkeypatch):
+        """Check that we can set the managed token flag via the environment variable
+        JOBSUB_MANAGED_TOKEN."""
+        monkeypatch.setenv("JOBSUB_MANAGED_TOKEN", "1")
+
+        args = get_parser.get_parser().parse_args([])
+        assert args.managed_token


### PR DESCRIPTION
This PR adds an environment variable, `JOBSUB_MANAGED_TOKEN`, corresponding to the new `--managed-token` flag, that allows users to set that flag in the environment


```
# Default behavior
$  bin/jobsub_submit -G fermilab -n --debug file:///usr/bin/true
...
varg: {...  'managed_token': False, 'memory': '2GB', ...}
...

# With flag
$  bin/jobsub_submit -G fermilab -n --debug --managed-token file:///usr/bin/true | grep managed_token
...
varg: {... 'managed_token': True, 'memory': '2GB', ...}
...

# With env
$ JOBSUB_MANAGED_TOKEN=1 bin/jobsub_submit -G fermilab -n --debug file:///usr/bin/true
...
varg: {...  managed_token': True, 'memory': '2GB', ...}
...
```

There are also a couple of tests that check this.