### PR TITLE
Add a "did you mean" clause for invalid but close to right auth methods

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -20,7 +20,7 @@ import difflib
 import os
 import re
 import sys
-from typing import Union, Any
+from typing import Union, Any, List
 
 from condor import get_schedd_names
 from creds import SUPPORTED_AUTH_METHODS, REQUIRED_AUTH_METHODS
@@ -152,7 +152,7 @@ class CheckIfValidAuthMethod(argparse.Action):
         setattr(namespace, self.dest, ",".join(check_values))
 
     @staticmethod
-    def __get_msg_from_close_val(value: str, valid_values: list[str]) -> str:
+    def __get_msg_from_close_val(value: str, valid_values: List[str]) -> str:
         """If our value is close to a valid value, return a message asking if the user meant
         the valid value.  Otherwise, return an empty string"""
         did_you_mean_str = " You provided '{value}' - did you mean '{close_match}'?"

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -139,7 +139,7 @@ class CheckIfValidAuthMethod(argparse.Action):
             for val in check_values:
                 close_match = difflib.get_close_matches(val, REQUIRED_AUTH_METHODS, n=1)
                 if len(close_match) > 0:
-                    msg_add = (
+                    msg_add += (
                         f" You provided '{val}' - did you mean '{close_match[0]}'?"
                     )
             raise ValueError(

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -137,11 +137,7 @@ class CheckIfValidAuthMethod(argparse.Action):
         if len(set(REQUIRED_AUTH_METHODS).intersection(set(check_values))) == 0:
             msg_add = ""
             for val in check_values:
-                close_match = difflib.get_close_matches(val, REQUIRED_AUTH_METHODS, n=1)
-                if len(close_match) > 0:
-                    msg_add += (
-                        f" You provided '{val}' - did you mean '{close_match[0]}'?"
-                    )
+                msg_add += self.__get_msg_from_close_val(val, REQUIRED_AUTH_METHODS)
             raise ValueError(
                 "The jobsub_lite infrastructure requires that the following "
                 f"authorization methods be present: {REQUIRED_AUTH_METHODS}.{msg_add}"
@@ -149,18 +145,23 @@ class CheckIfValidAuthMethod(argparse.Action):
 
         for value in check_values:
             if value not in SUPPORTED_AUTH_METHODS:
-                msg_add = ""
-                close_match = difflib.get_close_matches(
-                    value, SUPPORTED_AUTH_METHODS, n=1
-                )
-                if len(close_match) > 0:
-                    msg_add = (
-                        f" You provided '{value}' - did you mean '{close_match[0]}'?"
-                    )
+                msg_add = self.__get_msg_from_close_val(value, SUPPORTED_AUTH_METHODS)
                 raise ValueError(
                     f"Invalid auth method {value}.  Supported auth methods are {SUPPORTED_AUTH_METHODS}.{msg_add}"
                 )
         setattr(namespace, self.dest, ",".join(check_values))
+
+    @staticmethod
+    def __get_msg_from_close_val(value: str, valid_values: list[str]) -> str:
+        """If our value is close to a valid value, return a message asking if the user meant
+        the valid value.  Otherwise, return an empty string"""
+        did_you_mean_str = " You provided '{value}' - did you mean '{close_match}'?"
+        close_match = difflib.get_close_matches(value, valid_values, n=1)
+        return (
+            did_you_mean_str.format(value=value, close_match=close_match[0])
+            if len(close_match) > 0
+            else ""
+        )
 
 
 # Parsers

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -619,7 +619,7 @@ class TestGetParserUnit:
         from creds import REQUIRED_AUTH_METHODS
 
         with pytest.raises(
-            TypeError,
+            ValueError,
             match=rf"({auth_methods_args_test_case.bad_auth_method}|{REQUIRED_AUTH_METHODS})",
         ):
             check_valid_auth_method_arg_parser.parse_args(
@@ -706,7 +706,10 @@ class TestGetParserUnit:
     )
     @pytest.mark.unit
     def test_CheckAuthMethod_diffs(
-        self, auth_arg, expected_error_context, check_valid_auth_method_arg_parser
+        self,
+        auth_arg,
+        expected_error_context,
+        check_valid_auth_method_arg_parser,
     ):
         """Check to see if we provide an auth method that's either valid or close to a valid one,
         do we either get no error raised or get the "Did you mean" message in the raised ValueError

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -1,7 +1,9 @@
+from contextlib import nullcontext as does_not_raise
 from collections import namedtuple
 import json
 import os
 import sys
+
 import pytest
 
 #
@@ -685,3 +687,29 @@ class TestGetParserUnit:
 
         args = get_parser.get_parser().parse_args([])
         assert args.managed_token == expected_value
+
+    @pytest.mark.parametrize(
+        "auth_arg,expected_error_context",
+        [
+            ("token", does_not_raise()),  # Thanks https://stackoverflow.com/a/68012715
+            ("tokens", pytest.raises(ValueError, match=r".+requires.+did you mean.+")),
+            ("proxies", pytest.raises(ValueError, match=r".+requires.+")),
+            (
+                "token,proxies",
+                pytest.raises(ValueError, match=r".+Supported.+did you mean.+"),
+            ),
+            (
+                "tokens,proxies",
+                pytest.raises(ValueError, match=r".+requires.+did you mean.+"),
+            ),
+        ],
+    )
+    @pytest.mark.unit
+    def test_CheckAuthMethod_diffs(
+        self, auth_arg, expected_error_context, check_valid_auth_method_arg_parser
+    ):
+        """Check to see if we provide an auth method that's either valid or close to a valid one,
+        do we either get no error raised or get the "Did you mean" message in the raised ValueError
+        """
+        with expected_error_context:
+            check_valid_auth_method_arg_parser.parse_args(["--auth-methods", auth_arg])


### PR DESCRIPTION
Closes #595 

This just adds a `difflib` check that drives a "Did you mean..." error message.  This PR includes accompanying tests.

For example:

```
# Current default

$ bin/jobsub_submit -G fermilab --auth-methods token,proxy -n file:///bin/true                             
Submission files are in: /home/sbhat/.cache/jobsub_lite/js_2025_02_05_174257_7cbc693c-e519-483a-914d-1a381e3b796b


# Good case
$ bin/jobsub_submit -G fermilab --auth-methods token -n file:///bin/true
Storing bearer token in /tmp/bt_token_fermilab_Analysis_10610
Submission files are in: /home/sbhat/.cache/jobsub_lite/js_2025_02_05_174223_fc719f07-5266-4aae-a97b-25cfb2b8daf8

# tokens instead of token
$ bin/jobsub_submit -G fermilab --auth-methods tokens -n file:///bin/true                                  


Error: ValueError: The jobsub_lite infrastructure requires that the following authorization methods be present: ['token']. You provided 'tokens' - did you mean 'token'?

# proxies instead of proxy
$ bin/jobsub_submit -G fermilab --auth-methods token,proxies -n file:///bin/true                           


Error: ValueError: Invalid auth method proxies.  Supported auth methods are ['token', 'proxy']. You provided 'proxies' - did you mean 'proxy'?


# tokens instead of token, but token is required, so it'll fail
$ bin/jobsub_submit -G fermilab --auth-methods tokens,proxy -n file:///bin/true                            


Error: ValueError: The jobsub_lite infrastructure requires that the following authorization methods be present: ['token']. You provided 'tokens' - did you mean 'token'?
```