### PR TITLE
If JOBSUB_MANAGED_TOKEN is set to anything that implies False, set managed_token arg to False

### DIFF
--- a/lib/condor.py
+++ b/lib/condor.py
@@ -298,6 +298,7 @@ def record_vault_storer_run(
 
 NO_OP_STORER = "/bin/true"
 
+
 # pylint: disable=dangerous-default-value,too-many-locals,too-many-branches,too-many-statements
 @as_span("submit", arg_attrs=["*"])
 def submit(
@@ -341,7 +342,7 @@ def submit(
 
     verbose = int(vargs.get("verbose", 0))
 
-    if vargs["managed_token"] and ran_vault_storer_recently(
+    if vargs.get("managed_token", False) and ran_vault_storer_recently(
         schedd_name, vargs["oauth_handle"], vargs["outbase"], verbose
     ):
         _sec_cred_storer_val = NO_OP_STORER
@@ -405,7 +406,7 @@ def submit(
             )
             return None
 
-        if vargs["managed_token"] and _sec_cred_storer_val != NO_OP_STORER:
+        if vargs.get("managed_token", False) and _sec_cred_storer_val != NO_OP_STORER:
             record_vault_storer_run(
                 schedd_name, vargs["oauth_handle"], vargs["outbase"], verbose
             )

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -483,7 +483,8 @@ def get_parser() -> argparse.ArgumentParser:
         "--managed-token",
         action="store_const",
         const=True,
-        default=os.environ.get("JOBSUB_MANAGED_TOKEN", None) is not None,
+        default=os.environ.get("JOBSUB_MANAGED_TOKEN", "").lower()
+        not in ["0", "false", "", "no"],
         help="Will attempt to bypass calling condor_vault_storer during job submission. "
         "Assumes that vault token is managed externally, so condor_vault_storer will "
         "only be called once every six days.",

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -663,10 +663,25 @@ class TestGetParserUnit:
                 os.environ["JOBSUB_MANAGED_TOKEN"] = old_managed_token_env_value
 
     @pytest.mark.unit
-    def test_managed_token_flag_env_set(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "env_value,expected_value",
+        [
+            ("1", True),
+            ("0", False),
+            ("", False),
+            ("true", True),
+            ("false", False),
+            ("True", True),
+            ("False", False),
+            ("foo", True),
+            ("No", False),
+            ("no", False),
+        ],
+    )
+    def test_managed_token_flag_env_set(self, env_value, expected_value, monkeypatch):
         """Check that we can set the managed token flag via the environment variable
         JOBSUB_MANAGED_TOKEN."""
-        monkeypatch.setenv("JOBSUB_MANAGED_TOKEN", "1")
+        monkeypatch.setenv("JOBSUB_MANAGED_TOKEN", env_value)
 
         args = get_parser.get_parser().parse_args([])
-        assert args.managed_token
+        assert args.managed_token == expected_value


### PR DESCRIPTION
The list of items that will be interpreted as False is any capitalization of the strings "0", "false", "no", and the empty string "".

This PR includes new tests to check for "falsey" values.