### PR TITLE
Make subparsers clearer

### DIFF
--- a/bin/jobsub
+++ b/bin/jobsub
@@ -4,6 +4,9 @@ import os
 import os.path
 import sys
 
+from functools import partial
+from typing import Callable, Type
+
 if os.environ.get("LD_LIBRARY_PATH", ""):
     os.environ["HIDE_LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
     del os.environ["LD_LIBRARY_PATH"]
@@ -29,6 +32,16 @@ from get_parser import (
     get_condor_epilog,
 )
 from tracing import as_span
+from version import version_string
+
+
+def _help_action_factory(help_func: Callable[[None], None]) -> Type[argparse.Action]:
+    class _HelpAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            help_func()
+            parser.exit()
+
+    return _HelpAction
 
 
 @as_span(
@@ -38,27 +51,62 @@ from tracing import as_span
     is_main=True,
 )
 def main():
-    top_parser = argparse.ArgumentParser()
+    top_parser = argparse.ArgumentParser(add_help=False)
     subparsers = top_parser.add_subparsers()
+    _subparsers = []  # collect all the subparsers as we define them
+
     for sc in ("submit", "submit_dag"):
-        sub_parser = get_parser(parser=subparsers.add_parser(sc))
+        sub_parser = subparsers.add_parser(sc)  # Get a subparser for the subcommand sc
+        sub_parser = get_parser(
+            parser=sub_parser
+        )  # Mutate sub_parser with get_parser()
         sub_parser.set_defaults(command=f"jobsub_{sc}")
         sub_parser.set_defaults(func=jobsub_submit_args)
+        _subparsers.append(sub_parser)
 
     for sc in ("q", "hold", "release", "rm", "wait"):
+        sub_parser = subparsers.add_parser(
+            sc,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=get_condor_epilog(f"condor_{sc}"),
+        )  # Get a subparser for the subcommand sc
         sub_parser = jobsub_cmd_parser(
-            sc == "q",
-            parser=subparsers.add_parser(
-                sc,
-                formatter_class=argparse.RawDescriptionHelpFormatter,
-                epilog=get_condor_epilog(f"condor_{sc}"),
-            ),
-        )
+            sc == "q", parser=sub_parser
+        )  # Mutate sub_parser with jobsub_cmd_parser()
         sub_parser.set_defaults(command=f"jobsub_{sc}")
         sub_parser.set_defaults(func=jobsub_cmd_args)
-    sub_parser = jobsub_fetchlog_parser(parser=subparsers.add_parser("fetchlog"))
-    sub_parser.set_defaults(command="jobsub_fetchlog")
-    sub_parser.set_defaults(func=jobsub_fetchlog_args)
+        _subparsers.append(sub_parser)
+
+    fetchlog_sub_parser = subparsers.add_parser("fetchlog")  # fetchlog subparser
+    fetchlog_sub_parser = jobsub_fetchlog_parser(
+        parser=fetchlog_sub_parser
+    )  # Mutate fetchlog_sub_parser with jobsub_fetchlog_parser()
+    fetchlog_sub_parser.set_defaults(command="jobsub_fetchlog")
+    fetchlog_sub_parser.set_defaults(func=jobsub_fetchlog_args)
+    _subparsers.append(fetchlog_sub_parser)
+
+    # Print all the help strings if nothing is given. Thanks to the various discussions
+    # at https://stackoverflow.com/questions/20094215/argparse-subparser-monolithic-help-output
+    _helps = [top_parser.format_help()] + [
+        p.format_help() for p in _subparsers
+    ]  # collect all the help strings
+    help_func = lambda x, y: print("\n\n".join(_helps))
+    help_action = _help_action_factory(partial(help_func, x=None, y=None))
+
+    top_parser.set_defaults(
+        func=help_func
+    )  # We take 2 arguments in the lambda because the call to args.func below passes 2 arguments
+    top_parser.add_argument(
+        "-h",
+        "--help",
+        action=help_action,
+        nargs=0,
+    )
+    top_parser.add_argument(
+        "--version",
+        action="version",
+        version=version_string(),
+    )
 
     args, passthru = top_parser.parse_known_args()
     args.func(args, passthru)

--- a/bin/jobsub
+++ b/bin/jobsub
@@ -31,7 +31,12 @@ from get_parser import (
 from tracing import as_span
 
 
-@as_span(os.path.basename(f"{sys.argv[0]}_{sys.argv[1]}"), is_main=True)
+@as_span(
+    os.path.basename(
+        f"{sys.argv[0]}_{sys.argv[1]}" if len(sys.argv) > 1 else sys.argv[0]
+    ),
+    is_main=True,
+)
 def main():
     top_parser = argparse.ArgumentParser()
     subparsers = top_parser.add_subparsers()

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -20,6 +20,7 @@ import difflib
 import os
 import re
 from typing import Union, Any, Optional, List
+from version import version_string
 
 from condor import get_schedd_names
 from creds import SUPPORTED_AUTH_METHODS, REQUIRED_AUTH_METHODS
@@ -239,9 +240,8 @@ def get_base_parser(
     )
     group.add_argument(
         "--version",
-        action="store_true",
-        help="version of jobsub_lite being used",
-        default=False,
+        action="version",
+        version=version_string(),
     )
     group.add_argument(
         "--support-email",

--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" argument parser, used multiple places, so defined here"""
+"""argument parser, used multiple places, so defined here"""
 # pylint: disable=too-few-public-methods
 import argparse
 import difflib
@@ -169,7 +169,11 @@ class CheckIfValidAuthMethod(argparse.Action):
 def get_base_parser(
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> argparse.ArgumentParser:
-    """build the general jobsub command argument parser and return it"""
+    """Build the general jobsub command argument parser and return it
+
+    If parser is given (not None), then this function will modify parser directly.
+    Otherwise, it will use a new argparse.ArgumentParser.
+    """
 
     if parser is None:
         parser = argparse.ArgumentParser()
@@ -257,7 +261,11 @@ def get_base_parser(
 def get_submit_parser(
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> argparse.ArgumentParser:
-    """build the jobsub argument parser for the condor_submit/condor_submit_dag commands and return it"""
+    """Build the jobsub argument parser for the condor_submit/condor_submit_dag commands and return it.
+
+    If parser is given (not None), then this function will modify parser directly.
+    Otherwise, it will use a new argparse.ArgumentParser.
+    """
     parser = get_base_parser(parser=parser)
     parser.add_argument(
         "--job-info",
@@ -283,7 +291,11 @@ def get_submit_parser(
 def get_jobid_parser(
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> argparse.ArgumentParser:
-    """build the jobsub_cmd (jobsub_q, etc.) argument parser and return it"""
+    """Build the jobsub_cmd (jobsub_q, etc.) argument parser and return it.
+
+    If parser is given (not None), then this function will modify parser directly.
+    Otherwise, it will use a new argparse.ArgumentParser.
+    """
     parser = get_base_parser(parser=parser)
     parser.add_argument("-J", "--jobid", dest="jobid", help="job/submission ID")
     parser.add_argument(
@@ -297,7 +309,11 @@ def get_jobid_parser(
 def get_parser(
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> argparse.ArgumentParser:
-    """build the jobsub_submit argument parser and return it"""
+    """Build the jobsub_submit argument parser and return it.
+
+    If parser is given (not None), then this function will modify parser directly.
+    Otherwise, it will use a new argparse.ArgumentParser.
+    """
     parser = get_submit_parser(parser)
     parser.add_argument(
         "-c",

--- a/lib/mains/cmd.py
+++ b/lib/mains/cmd.py
@@ -76,30 +76,32 @@ def jobsub_cmd_main(argv: List[str] = sys.argv) -> None:
 def jobsub_cmd_args(arglist: argparse.Namespace, passthru: List[str]) -> None:
     global VERBOSE  # pylint: disable=invalid-name,global-statement
 
-    VERBOSE = arglist.verbose
+    VERBOSE = getattr(arglist, "verbose", 0)
 
     log_host_time(VERBOSE)
     totalsf = None
 
-    if arglist.version:
+    # If called from jobsub or jobsub_* commands, this is redundant. However, we keep it in there
+    # for the case where the user imports this module and calls jobsub_cmd_args directly.
+    if getattr(arglist, "version", False):
         version.print_version()
         return
 
-    if arglist.support_email:
+    if getattr(arglist, "support_email", False):
         version.print_support_email()
         return
 
     # Re-insert --debug/--VERBOSE if it was given
-    if arglist.verbose:
+    if VERBOSE:
         passthru.append("-debug")
     # if they gave us --jobid or --user put in the value plain, condor figures it out
-    if arglist.jobid:
+    if getattr(arglist, "jobid", None):
         for jid in arglist.jobid.split(","):
             passthru.append(jid)
-    if hasattr(arglist, "user") and arglist.user:
+    if getattr(arglist, "user", None):
         passthru.append(arglist.user)
     # If they gave us --constraint, sanitize it and add to passthru
-    if arglist.constraint:
+    if getattr(arglist, "constraint", None):
         passthru.extend(["-constraint", arglist.constraint])
 
     if os.environ.get("GROUP", None) is None:
@@ -114,7 +116,7 @@ def jobsub_cmd_args(arglist: argparse.Namespace, passthru: List[str]) -> None:
     # save beginning of 1234@schedd in list of args for that schedd
     args_for_schedd = defaultdict(list)
 
-    if arglist.name:
+    if getattr(arglist, "name", None):
         schedd_list.add(arglist.name)
 
     default_formatting = True

--- a/lib/mains/cmd.py
+++ b/lib/mains/cmd.py
@@ -4,7 +4,7 @@
 # api -- calls for apis
 #
 
-""" python command  apis for jobsub """
+"""python command  apis for jobsub"""
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 import argparse
 import io
@@ -45,7 +45,7 @@ class StoreGroupinEnvironment(argparse.Action):
 
 
 def jobsub_cmd_parser(
-    jobsub_q_flag: bool, parser: Optional[argparse.ArgumentParser]
+    jobsub_q_flag: bool = False, parser: Optional[argparse.ArgumentParser] = None
 ) -> argparse.ArgumentParser:
     parser = get_parser.get_jobid_parser(parser=parser)
     parser.add_argument("-name", help="Set schedd name", default=None)
@@ -62,7 +62,6 @@ def jobsub_cmd_parser(
 # pylint: disable=dangerous-default-value
 @as_span("jobsub_cmd", is_main=True)
 def jobsub_cmd_main(argv: List[str] = sys.argv) -> None:
-
     """main line of code, proces args, etc."""
     condor_cmd = os.path.basename(argv[0]).replace("jobsub_", "condor_")
     parser = argparse.ArgumentParser(epilog=get_parser.get_condor_epilog(condor_cmd))

--- a/lib/mains/fetchlog.py
+++ b/lib/mains/fetchlog.py
@@ -4,7 +4,7 @@
 # api -- calls for apis
 #
 
-""" python command  apis for jobsub """
+"""python command  apis for jobsub"""
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 import argparse
 import os
@@ -250,6 +250,8 @@ def jobsub_fetchlog_args(
 
     log_host_time(VERBOSE)
 
+    # If called from jobsub or jobsub_* commands, this is redundant. However, we keep it in there
+    # for the case where the user imports this module and calls jobsub_cmd_args directly.
     if args.version:
         version.print_version()
         return

--- a/lib/mains/fetchlog.py
+++ b/lib/mains/fetchlog.py
@@ -243,7 +243,7 @@ def jobsub_fetchlog_args(
 ) -> None:
 
     global VERBOSE  # pylint: disable=global-statement
-    VERBOSE = args.verbose
+    VERBOSE = getattr(args, "verbose", 0)
 
     if passthru:
         raise argparse.ArgumentError(None, f"unknown arguments: {repr(passthru)}")
@@ -251,31 +251,30 @@ def jobsub_fetchlog_args(
     log_host_time(VERBOSE)
 
     # If called from jobsub or jobsub_* commands, this is redundant. However, we keep it in there
-    # for the case where the user imports this module and calls jobsub_cmd_args directly.
-    if args.version:
+    # for the case where the user imports this module and calls jobsub_fetchlog_args directly.
+    if getattr(args, "version", False):
         version.print_version()
         return
 
-    if args.support_email:
+    if getattr(args, "support_email", False):
         version.print_support_email()
         return
 
     # jobsub_fetchlog only supports tokens
-    if "token" not in args.auth_methods:
+    if "token" not in getattr(args, "auth_methods", ["token"]):
         raise SystemExit(
             "jobsub_fetchlog only supports token authentication.  Please either omit the --auth-methods flag or make sure tokens is included in the value of that flag"
         )
 
-    if not args.jobid and not args.job_id:
-        raise SystemExit("jobid is required.")
-
-    if not args.jobid and args.job_id:
-        args.jobid = args.job_id
+    if not getattr(args, "jobid", None):
+        if getattr(args, "job_id", None) is None:
+            raise SystemExit("jobid is required.")
+        setattr(args, "jobid", args.job_id)
 
     # handle 1234.@jobsub0n.fnal.gov
     args.jobid = args.jobid.replace(".@", "@")
 
-    if args.verbose:
+    if VERBOSE:
         htcondor.set_subsystem("TOOL")
         htcondor.param["TOOL_DEBUG"] = "D_FULLDEBUG"
         htcondor.enable_debug()
@@ -284,8 +283,15 @@ def jobsub_fetchlog_args(
         raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     cred_set = creds.get_creds(vars(args))
-    if args.verbose:
+    if VERBOSE:
         creds.print_cred_paths_from_credset(cred_set)
 
-    fetcher = fetch_from_condor if args.condor else fetch_from_landscape
-    fetcher(args.jobid, args.destdir, args.archive_format, args.partial)
+    fetcher = (
+        fetch_from_condor if getattr(args, "condor", False) else fetch_from_landscape
+    )
+    fetcher(
+        args.jobid,
+        getattr(args, "destdir", None),
+        getattr(args, "archive_format", "tar"),
+        getattr(args, "partial", False),
+    )

--- a/lib/mains/submit.py
+++ b/lib/mains/submit.py
@@ -84,8 +84,8 @@ def jobsub_submit_main(argv: List[str] = sys.argv) -> None:
 def jobsub_submit_args(
     args: argparse.Namespace, passthru: Optional[List[str]] = None
 ) -> None:
-
     global VERBOSE  # pylint: disable=global-statement
+    VERBOSE = getattr(args, "verbose", 0)
 
     if passthru:
         raise argparse.ArgumentError(None, f"unknown arguments: {repr(passthru)}")
@@ -123,8 +123,6 @@ def jobsub_submit_args(
 
     sanitize_lines(getattr(args, "lines", []))
 
-    VERBOSE = getattr(args, "verbose", 0)
-
     log_host_time(VERBOSE)
 
     # if they were trying to pass LD_LIBRARY_PATH to the job, get it from HIDE_LD_LIBRARY_PATH
@@ -147,7 +145,7 @@ def jobsub_submit_args(
         return
 
     if getattr(args, "skip_check", []):
-        if getattr(args, "verbose", 0):
+        if VERBOSE:
             print(f"Will skip these checks: {args.skip_check}")
         # Run all the setup items for each check to skip
         for check in args.skip_check:

--- a/lib/mains/submit.py
+++ b/lib/mains/submit.py
@@ -115,6 +115,8 @@ def jobsub_submit_args(
             for x in args.environment
         ]
 
+    # If called from jobsub or jobsub_* commands, this is redundant. However, we keep it in there
+    # for the case where the user imports this module and calls jobsub_submit_args directly.
     if args.version:
         version.print_version()
         return

--- a/lib/mains/submit.py
+++ b/lib/mains/submit.py
@@ -74,10 +74,10 @@ def jobsub_submit_main(argv: List[str] = sys.argv) -> None:
 
     args = parser.parse_args(argv[1:])
 
-    if args.verbose:
+    if getattr(args, "verbose", 0):
         print("in jobsub_submit_main: args = ", args)
 
-    VERBOSE = args.verbose
+    VERBOSE = getattr(args, "verbose", 0)
     jobsub_submit_args(args)
 
 
@@ -90,19 +90,40 @@ def jobsub_submit_args(
     if passthru:
         raise argparse.ArgumentError(None, f"unknown arguments: {repr(passthru)}")
 
-    if not args.global_pool and os.environ.get("JOBSUB_GLOBAL_POOL", ""):
+    if not getattr(args, "global_pool", "") and os.environ.get(
+        "JOBSUB_GLOBAL_POOL", ""
+    ):
         pool.set_pool(os.environ["JOBSUB_GLOBAL_POOL"])
 
     # Allow environment variables to append to some command lists to get rid of
     # need for poms_jobsub_wrapper to get in front of us on the path -- we will
     # just set these and have a job-info script report the job id, etc.
-    args.environment.extend(get_env_list("JOBSUB_EXTRA_ENVIRONMENT"))
-    args.lines.extend(get_env_list("JOBSUB_EXTRA_LINES"))
-    args.job_info.extend(get_env_list("JOBSUB_EXTRA_JOB_INFO"))
+    def _extend_args_attr_if_exists(
+        args: argparse.Namespace, attr: str, env_list: List[str]
+    ) -> argparse.Namespace:
+        # _list gets set to None if args.attr is not set or is None
+        _list = getattr(args, attr, None)
+        try:
+            assert _list is not None
+        except AssertionError:
+            _list = []
+        _list.extend(env_list)
+        setattr(args, attr, _list)
+        return args
 
-    sanitize_lines(args.lines)
+    args = _extend_args_attr_if_exists(
+        args, "environment", get_env_list("JOBSUB_EXTRA_ENVIRONMENT")
+    )
+    args = _extend_args_attr_if_exists(
+        args, "lines", get_env_list("JOBSUB_EXTRA_LINES")
+    )
+    args = _extend_args_attr_if_exists(
+        args, "job_info", get_env_list("JOBSUB_EXTRA_JOB_INFO")
+    )
 
-    VERBOSE = args.verbose
+    sanitize_lines(getattr(args, "lines", []))
+
+    VERBOSE = getattr(args, "verbose", 0)
 
     log_host_time(VERBOSE)
 
@@ -117,16 +138,16 @@ def jobsub_submit_args(
 
     # If called from jobsub or jobsub_* commands, this is redundant. However, we keep it in there
     # for the case where the user imports this module and calls jobsub_submit_args directly.
-    if args.version:
+    if getattr(args, "version", False):
         version.print_version()
         return
 
-    if args.support_email:
+    if getattr(args, "support_email", False):
         version.print_support_email()
         return
 
-    if args.skip_check:
-        if args.verbose:
+    if getattr(args, "skip_check", []):
+        if getattr(args, "verbose", 0):
             print(f"Will skip these checks: {args.skip_check}")
         # Run all the setup items for each check to skip
         for check in args.skip_check:
@@ -135,19 +156,23 @@ def jobsub_submit_args(
     # We want to push users to use jobsub_submit --dag, but there are still some legacy
     # users who use the old jobsub_submit_dag executable.  This patches that use case
     if os.path.basename(sys.argv[0]) == "jobsub_submit_dag":
-        args.dag = True
+        setattr(args, "dag", True)
 
     if os.environ.get("GROUP", None) is None:
         raise SystemExit(f"{sys.argv[0]} needs -G group or $GROUP in the environment.")
 
     # While we're running in hybrid proxy/token mode, force us to get a new proxy every time we submit
     # Eventually, this arg and its support in the underlying libraries should be removed
-    args.force_proxy = True
+    setattr(args, "force_proxy", True)
 
     tarfiles.do_tarballs(args)
 
-    if args.maxConcurrent and int(args.maxConcurrent) >= args.N and not args.dag:
-        if args.verbose:
+    if (
+        getattr(args, "maxConcurrent", None)
+        and int(args.maxConcurrent) >= getattr(args, "N", 1)
+        and not getattr(args, "dag", False)
+    ):
+        if VERBOSE:
             sys.stderr.write(
                 f"Note: ignoring --maxConcurrent {args.maxConcurrent} for {args.N} jobs\n"
             )
@@ -156,10 +181,10 @@ def jobsub_submit_args(
     varg = vars(args)
 
     cred_set = creds.get_creds(varg)
-    if args.verbose:
+    if VERBOSE:
         creds.print_cred_paths_from_credset(cred_set)
 
-    if args.verbose:
+    if VERBOSE:
         sys.stderr.write(f"varg: {repr(varg)}\n")
 
     schedd_add = condor.get_schedd(varg)
@@ -184,7 +209,11 @@ def jobsub_submit_args(
     if cred_set.token:
         cred_set.token = use_token_copy(cred_set.token)
         varg["job_scope"] = " ".join(
-            get_job_scopes(cred_set.token, args.need_storage_modify, args.need_scope)
+            get_job_scopes(
+                cred_set.token,
+                getattr(args, "need_storage_modify", []),
+                getattr(args, "need_scope", []),
+            )
         )
         m = hashlib.sha256()
         m.update(varg["job_scope"].encode())
@@ -202,7 +231,7 @@ def jobsub_submit_args(
         else:
             jobsub_submit_simple(varg, schedd_name)
 
-        if args.verbose:
+        if VERBOSE:
             # remind folks where transferred data goes.
             for f in args.orig_input_file:
                 print(

--- a/lib/mains/submit.py
+++ b/lib/mains/submit.py
@@ -4,7 +4,7 @@
 # api -- calls for apis
 #
 
-""" python command  apis for jobsub """
+"""python command  apis for jobsub"""
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 import argparse
 import hashlib
@@ -48,6 +48,7 @@ import skip_checks
 
 from .common import VERBOSE
 
+
 # pylint: disable=too-many-branches,too-many-statements,dangerous-default-value
 @as_span("jobsub_submit", is_main=True)
 def jobsub_submit_main(argv: List[str] = sys.argv) -> None:
@@ -73,7 +74,8 @@ def jobsub_submit_main(argv: List[str] = sys.argv) -> None:
 
     args = parser.parse_args(argv[1:])
 
-    print("in jobsub_submit_main: args = ", args)
+    if args.verbose:
+        print("in jobsub_submit_main: args = ", args)
 
     VERBOSE = args.verbose
     jobsub_submit_args(args)

--- a/lib/version.py
+++ b/lib/version.py
@@ -25,8 +25,12 @@ __author__ = "Fermi National Accelerator Laboratory"
 __copyright__ = f"2023 {__author__}"
 
 
+def version_string() -> str:
+    return f"{__title__} version {__version__}"
+
+
 def print_version() -> None:
-    print(f"{__title__} version {__version__}")
+    print(version_string())
 
 
 def print_support_email() -> None:

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -422,6 +422,7 @@ class TestGetParserUnit:
             "--constraint",
             "--skip-check",  # Skipping this one because we do a special test later on for this
             "--schedd-for-testing",  # Skipping this one because we do a special test later on for this
+            "--version",  # Skipping this because we do a special test separately
         ]
 
         def filter_excluded(arg_list):
@@ -715,3 +716,13 @@ class TestGetParserUnit:
         """
         with expected_error_context:
             check_valid_auth_method_arg_parser.parse_args(["--auth-methods", auth_arg])
+
+    @pytest.mark.unit
+    def test_version(self, capsys):
+        """Make sure we can print the version"""
+        with pytest.raises(SystemExit):
+            parser = get_parser.get_parser()
+            parser.parse_args(["--version"])
+            captured = capsys.readouterr()
+            assert "jobsub_lite" in captured.out
+            assert "version" in captured.out


### PR DESCRIPTION
This PR started out as a simple task to make the new subparser logic a bit clearer.  I ended up doing a bit of code cleanup at the same time, since unit tests were failing due to assumptions we can no longer make.  The changes, at a high level are as follows:

1. `lib/mains/*.py`: Most of the `jobsub_*_args` functions now accept an `argparse.Namespace` for better modularity.  However, we weren't checking for certain attributes (like `verbose`, etc.) to be set when executing different branches. This caused unit tests to fail; and I mostly substituted calls like `args.verbose` with `getattr(args, "verbose", 0)` (or some other sensible default given `lib/get_parser.py`)
2. `lib/get_parser.py`: Python's `argparse` library comes with a built-in `version` action. I simply use it in our parsers, since it makes the most sense, and provides an example of what other users should do.
3. `bin/jobsub`: Cleaned/cleared up the subparser invocation logic in `jobsub`, so it's very clear that for each kind of parser, we're 
   1. Setting up a subparser
   2. Mutating it with various `lib/get_parser.py` functions
   3. Setting defaults
 
(3) also fulfilled the original spec, so that if one types `jobsub`, they should get all subparsers' help messages.