### PR TITLE
Fixed unit test after --maxConcurrent type restriction

### DIFF
--- a/bin/jobsub_submit
+++ b/bin/jobsub_submit
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" submit command for jobsub layer over condor """
+"""submit command for jobsub layer over condor"""
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 import hashlib
 import os
@@ -147,7 +147,7 @@ def main():
             sys.stderr.write(
                 f"Note: ignoring --maxConcurrent {args.maxConcurrent} for {args.N} jobs\n"
             )
-        args.maxConcurrent = None
+        args.maxConcurrent = 0
 
     varg = vars(args)
 

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -192,7 +192,7 @@ def all_test_args():
         "--mail-always",
         "--managed-token",
         "--maxConcurrent",
-        "xxmaxConcurrentxx",
+        0,
         "--memory",
         "xxmemoryxx",
         "--need-storage-modify",
@@ -387,9 +387,14 @@ class TestGetParserUnit:
             assert arg in all_test_args
 
         for arg in all_test_args:
-            if arg[0] == "-":
-                arg = arg.lstrip("-")
-                assert arg in allargs
+            try:
+                if arg[0] == "-":
+                    arg = arg.lstrip("-")
+                    assert arg in allargs
+            except (
+                TypeError
+            ):  # We have some non-string argument values in all_test_args
+                pass
 
     @pytest.mark.unit
     def test_get_parser_all(self, find_all_arguments, all_test_args):
@@ -473,6 +478,8 @@ class TestGetParserUnit:
                 assert vres["global_pool"] == "dune"
             elif arg == "dd-percentage":
                 assert vres["dd_percentage"] == 50
+            elif arg == "maxConcurrent":
+                assert vres["maxConcurrent"] == 0
             elif arg in listargs:
                 # args are in a list, so look for list containing xxflagxx
                 if arg in ["lines"]:


### PR DESCRIPTION
This unit test was assuming that maxConcurrent could be anything.  Now that it's an int, the test broke.  This PR fixes it.

Also, we had forgotten to coerce maxConcurrent to 0 if we were not using a DAG in certain cases.