### PR TITLE
Fix IFDH_VERSION behavior in job wrapper.

### DIFF
--- a/lib/mains/cmd.py
+++ b/lib/mains/cmd.py
@@ -248,7 +248,7 @@ def jobsub_cmd_args(arglist: argparse.Namespace, passthru: List[str]) -> None:
                 # pipe our remaining output through sort (by date) and jobsub_totals next to us
                 # ... if we're not collecting output for the API.
                 jobsub_totals_path = os.path.join(
-                    os.path.dirname(__file__), "../bin/jobsub_totals"
+                    os.path.dirname(__file__), "../../bin/jobsub_totals"
                 )
                 totalsf = os.popen(f"sort -k 3,4 | {jobsub_totals_path}", "w")
                 savout = os.dup(1)

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -177,7 +177,6 @@ if [ "$has_ifdh" -ne "0" ] ; then
     . /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh
     sos=$(spack arch --operating-system)
     spack env activate ifdh_env_${sos}_${IFDH_VERSION:-current} ||
-      echo Falling back to current ifdhc for this operation >&2 &&
       spack env activate ifdh_env_${sos}_current
 fi
 which ifdh > /dev/null 2>&1

--- a/templates/simple/simple.sh
+++ b/templates/simple/simple.sh
@@ -176,8 +176,9 @@ has_ifdh=$?
 if [ "$has_ifdh" -ne "0" ] ; then
     . /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh
     sos=$(spack arch --operating-system)
-    spack env activate ifdh_env_${sos}_${IFDH_VERSION:-current} ||
-      spack env activate ifdh_env_${sos}_current
+    spack env activate ifdh_env_${sos}_${IFDH_VERSION:-current} || {
+      echo Falling back to current ifdhc for this operation >&2 &&
+      spack env activate ifdh_env_${sos}_current ; }
 fi
 which ifdh > /dev/null 2>&1
 if [ "$?" -ne "0" ] ; then


### PR DESCRIPTION

It *should* activate the spack environment ending in $IFDH_VERSION, but instead 
the `echo &&` breaks desired behavior, and both spack environment activate  commands run 
and you end up with the last one...