### PR TITLE
Updated PAT to fine-grained token for better security

### DIFF
--- a/.github/workflows/build-al9-push.yaml
+++ b/.github/workflows/build-al9-push.yaml
@@ -24,5 +24,5 @@ jobs:
         with:
           repository: fermitools/jobsub_lite_config
           path: config
-          token: ${{ secrets.ACCESS_JOBSUB_LITE_CONFIG }}
+          token: ${{ secrets.ACCESS_JOBSUB_LITE_CONFIG_FINEGRAINED }}
       - uses: ./.github/actions/build-with-make-al9


### PR DESCRIPTION
As the title says.  The token used to checkout `jobsub_lite_config` now can ONLY do that.