### PR TITLE
Fix dash f pnfs bug

### DIFF
--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # pylint: disable=fixme
-""" tarfile upload related code """
+"""tarfile upload related code"""
 import argparse
 import errno
 import hashlib
@@ -280,6 +280,7 @@ def do_tarballs(args: argparse.Namespace) -> None:
                         res.append(pfn)
 
                 elif args.use_dropbox == "pnfs":
+                    get_creds(vars(args))
                     location = dcache_persistent_path(args.group, pfn)
                     existing = fake_ifdh.ls(location)
                     if existing:
@@ -366,10 +367,11 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
     # redo tarfile to have contents with world read perms before publishing
     tfn = tarchmod(origtfn, getattr(args, "verbose", 0))
 
+    cred_set = get_creds(vars(args))
+
     location: Optional[str] = ""
     if args.use_dropbox == "cvmfs" or args.use_dropbox is None:
         digest = checksum_file(tfn)
-        cred_set = get_creds(vars(args))
 
         if not args.group:
             raise ValueError("No --group specified!")
@@ -426,7 +428,6 @@ def tarfile_in_dropbox(args: argparse.Namespace, origtfn: str) -> Optional[str]:
             publisher.update_cid()
 
     elif args.use_dropbox == "pnfs":
-        cred_set = get_creds(vars(args))
         location = dcache_persistent_path(args.group, tfn)
         existing = fake_ifdh.ls(location)
         if existing:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ import creds
 
 
 @pytest.fixture
-def set_creds_dir(monkeypatch, tmp_path):
+def set_creds_dir(tmp_path):
     """
     Set the credentials directory to a temporary path for testing.
     """

--- a/tests/test_tarfiles_unit.py
+++ b/tests/test_tarfiles_unit.py
@@ -83,7 +83,7 @@ class TestTarfilesUnit:
     def teardown_class(cls):
         """Delete any test remnants"""
         cls.dir_to_tar.cleanup()
-        os.unlink(cls.test_tarfile)
+        cls.test_tarfile.unlink()
 
     # lib/tarfiles.py routines...
     @pytest.mark.unit
@@ -228,7 +228,6 @@ class TestTarfilesUnit:
     def test_do_tarballs_dash_f(self, dropbox_type, set_temp_bearer_token_file):
         """test that the do_tarballs method does a dropbox:path
         processing"""
-        # for dropbox_type in ["cvmfs", "pnfs"]:
         print(f"dropbox type: {dropbox_type}\n===============")
         argv = [
             "--auth-methods",


### PR DESCRIPTION
This PR fixes a bug where the following would fail, because we'd forgotten to ensure that a branch of the tarballs/dropbox code would obtain credentials:

```
jobsub_submit -G experiment --use-pnfs-dropbox -f dropbox://blahblah
```

It also starts to break out some of the test fixtures so we can get only tokens for our tests.

All tarfile unit tests pass with this PR (before, a number failed because of a failure to obtain a proxy after the CILogon CA shutdown).  There will be a number of other unit tests we'll have to update the same way to only get tokens.