### PR TITLE
Merge 1.11 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME = jobsub_lite
 # In most cases, these two lines should be ALL that need to be changed
 # Warning:  Make sure there is NO trailing whitespace in either of these lines!!
 # Set RC to 0 for final release
-VERSION = v1.11.1
+VERSION = v1.11.2
 RC = 0
 ### End expected changes
 

--- a/lib/version.py
+++ b/lib/version.py
@@ -17,7 +17,7 @@ __title__ = "jobsub_lite"
 __summary__ = "The local HTCondor job submission software for Fermilab users to submit jobs to local FermiGrid resources and to the Open Science Grid."
 __uri__ = "https://fifewiki.fnal.gov/wiki/Jobsub_Lite"
 
-__version__ = "1.11.1"
+__version__ = "1.11.2"
 __email__ = "jobsub-support@fnal.gov"
 
 __license__ = "Apache License, Version 2.0"


### PR DESCRIPTION
This merges the `1.11-release` branch into `master` to prep for the `1.12` release.  Since we were able to make changes to both the `1.11-release` and `master` branches with the bug fixes, we only have version changes to propagate from the `1.11-release` branch to `master`.

Closes #635 