### PR TITLE
Make sure we check for executable's existence before submitting job

### DIFF
--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -744,6 +744,6 @@ class TestGetParserUnit:
     @pytest.mark.unit
     def test_executable_arg_parser_invalid_DNE(self, executable_arg_parser):
         """This test makes sure that if we pass an invalid executable argument,
-        we get a TypeError"""
+        we get a FileNotFoundError"""
         with pytest.raises(FileNotFoundError, match="executable path does not exist"):
             executable_arg_parser.parse_args(["file:///bin/doesnotexist"])


### PR DESCRIPTION
Closes #631 

This PR upgrades the `executable` argument in the jobsub `get_parser` parser to use a custom `Action` that does two things:

1. Check that the executable argument is given with the correct URI (`file://`)
2. Check that the argument value for the executable actually exists.

There are added accompanying unit tests, as well as a couple of updates to old tests so that they work with this new restriction.

All unit tests pass, and further testing information is available in comments of #631.