### PR TITLE
Added support for using htcondor2 and classad2 libraries

### DIFF
--- a/bin/condor_submit
+++ b/bin/condor_submit
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" wrapper for condor submit """
+"""wrapper for condor submit"""
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
 import sys
 import os
@@ -28,7 +28,10 @@ if os.environ.get("LD_LIBRARY_PATH", ""):
     del os.environ["LD_LIBRARY_PATH"]
     os.execv(sys.argv[0], sys.argv)
 
-import htcondor
+try:
+    import htcondor2 as htcondor  # Condor 25 and later
+except ImportError:
+    import htcondor  # Condor 24 and earlier
 
 #
 # we are in prefix/bin/jobsub_submit, so find our prefix

--- a/lib/condor.py
+++ b/lib/condor.py
@@ -26,8 +26,13 @@ import time
 from typing import Dict, List, Any, Tuple, Optional, Union, Generator
 
 # pylint: disable=import-error
-import classad  # type: ignore
-import htcondor  # type: ignore
+try:  # Condor 25 and later
+    import classad2 as classad  # type: ignore
+    import htcondor2 as htcondor  # type: ignore
+except ImportError:  # Condor 24 and earlier
+    import classad  # type: ignore
+    import htcondor  # type: ignore
+
 import jinja2  # type: ignore
 
 import defaults
@@ -161,7 +166,7 @@ def get_schedd_list(
 
     # Get schedd ads from collector and store them in memory
     schedds: List[classad.ClassAd] = coll.query(
-        htcondor.htcondor.AdTypes.Schedd,
+        htcondor.AdTypes.Schedd,
         constraint=schedd_constraint,
     )
 
@@ -568,7 +573,7 @@ class Job:
             return f"{self.seq}@{self.schedd}"
         return f"{self.seq}.{self.proc}@{self.schedd}"
 
-    def _get_schedd(self) -> htcondor.htcondor.Schedd:
+    def _get_schedd(self) -> htcondor.Schedd:
         c = htcondor.Collector(COLLECTOR_HOST)
         s = c.locate(htcondor.DaemonTypes.Schedd, self.schedd)
         if s is None:

--- a/lib/cred_token.py
+++ b/lib/cred_token.py
@@ -25,8 +25,13 @@ from typing import Union, Optional, List, Tuple, Any
 
 # pylint: disable=import-error
 import jwt  # type: ignore
-import htcondor  # type: ignore # pylint: disable=wrong-import-position
 import scitokens  # type: ignore
+
+try:
+    import htcondor2 as htcondor  # type: ignore # pylint: disable=wrong-import-position # Condor 25 and later
+except ImportError:
+    import htcondor  # type: ignore # pylint: disable=wrong-import-position # Condor 24 and earlier
+
 
 from defaults import DEFAULT_ROLE  # pylint: disable=wrong-import-position
 from tracing import as_span, add_event  # pylint: disable=wrong-import-position

--- a/lib/jobsub_api.py
+++ b/lib/jobsub_api.py
@@ -6,7 +6,13 @@ import time
 import contextlib
 from datetime import datetime, timedelta
 from io import StringIO
-from htcondor import JobStatus  # type: ignore #pylint: disable=import-error
+
+try:  # Condor 25 and later
+    from htcondor2 import JobStatus  # type: ignore #pylint: disable=import-error
+except ImportError:  # Condor 24 and earlier
+    from htcondor import JobStatus  # type: ignore #pylint: disable=import-error
+
+
 from mains import jobsub_submit_main, jobsub_fetchlog_main, jobsub_cmd_main
 from condor import Job
 from tracing import as_span

--- a/lib/mains/fetchlog.py
+++ b/lib/mains/fetchlog.py
@@ -30,9 +30,14 @@ import get_parser
 
 from utils import cleanup
 import version
-import htcondor  # type: ignore # pylint: disable=wrong-import-position
 import creds
 import requests  # type: ignore
+
+try:
+    import htcondor2 as htcondor  # type: ignore # pylint: disable=wrong-import-position # Condor 25 and later
+except ImportError:
+    import htcondor  # type: ignore # pylint: disable=wrong-import-position # Condor 24 and earlier
+
 
 from .common import VERBOSE
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -29,12 +29,15 @@ import time
 from typing import Union, Dict, Any, NamedTuple, Tuple, List, Optional
 import uuid
 
-import classad  # type: ignore # pylint: disable=import-error
-from tracing import get_propagator_carrier  # pylint: disable=wrong-import-position
+try:  # Condor 25 and later
+    import classad2 as classad  # type: ignore # pylint: disable=import-error
+except ImportError:  # Condor 24 and earlier
+    import classad  # type: ignore # pylint: disable=import-error
 
 from creds import CredentialSet
 from defaults import DEFAULT_SINGULARITY_IMAGE, DEFAULT_USAGE_MODELS, ONSITE_SITE_NAME
 import token_mods
+from tracing import get_propagator_carrier
 import version
 
 


### PR DESCRIPTION
This PR adds conditional imports of the `htcondor2` and `classad2` Condor Python bindings.  We want to still support both `htcondor` and `classad`, since some client machines are running Condor 23, which does not have the `2` versions of those libraries.  

The plan is that in the upcoming release (1.13), we will support both `htcondor`/`classad` and the `2` versions of those, and then drop support for `htcondor`/`classad` in the 1.14 release.

This code has been exhaustively tested on the following condor combinations (each combination below is client --> schedd):

1. Condor 23 --> Condor 25 (Current FNAL production)
2. Condor 24 --> Condor 25
3. Condor 25 --> Condor 25 (Near future FNAL production)
4. Condor 25 --> Condor 24 (`condor_vault_storer` FAILS, but we never intend to use this combination, and it is probably independent of this change.)

Closes #663.