### PR TITLE
pre-commit.ci fixes 1.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,19 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    #rev: v0.931
+    rev: v1.10.0
     hooks:
       - id: mypy
         name: mypy (no tests or bin)
         exclude: ^(tests/|bin/)
         args: [--strict]
+        # additional_dependencies: [ typed-ast ]
       - id: mypy
         name: mypy (bin)
         files: bin/
         args: [ --scripts-are-modules,  --ignore-missing-imports ]
+        # additional_dependencies: [ typed-ast ]
   - repo: https://github.com/PyCQA/pylint
     rev:  v2.13.9
     hooks:
@@ -24,6 +27,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+# Do we need this?
 ci:
   autofix_prs: false
   autoupdate_branch: 'pre-commit.ci-autoupdate'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,29 +5,26 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-mypy
-    #rev: v0.931
     rev: v1.10.0
     hooks:
       - id: mypy
         name: mypy (no tests or bin)
         exclude: ^(tests/|bin/)
         args: [--strict]
-        # additional_dependencies: [ typed-ast ]
       - id: mypy
         name: mypy (bin)
         files: bin/
         args: [ --scripts-are-modules,  --ignore-missing-imports ]
-        # additional_dependencies: [ typed-ast ]
   - repo: https://github.com/PyCQA/pylint
     rev:  v2.13.9
     hooks:
       - id: pylint
         args: [--rcfile=.pylintrc] # Go through this.  Maybe we want to modify this list
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
-# Do we need this?
+
 ci:
   autofix_prs: false
   autoupdate_branch: 'pre-commit.ci-autoupdate'

--- a/lib/tarfiles.py
+++ b/lib/tarfiles.py
@@ -537,7 +537,7 @@ class TarfilePublisherHandler:
                 # Default value for restore_func.  In reality we won't use this value at all if should_change_selector_behavior is False
                 restore_func: Callable[
                     ..., Iterator[str]
-                ] = lambda: self._dropbox_server_selector  # type: ignore
+                ] = lambda: self._dropbox_server_selector
 
                 if should_change_selector_behavior:
                     restore_func = (


### PR DESCRIPTION
This fixes the various pre-commit.ci issues seen in PR #664.

The fixes were:
- Upgrade mypy to v1.10.0 so it uses the python `ast` library 
- Upgrade black to 22.8.0 so it uses the updated async calls in the python stdlib.