### PR TITLE
Fixed case where external callers (like POMS) run fake_ifdh.py getToken

### DIFF
--- a/lib/creds.py
+++ b/lib/creds.py
@@ -131,15 +131,15 @@ def resolve_auth_methods(arg_auth_method: Optional[str]) -> List[str]:
 
 # pylint: disable=unused-argument
 @as_span("getRole")
-def getRole(role_override: Optional[str] = None, verbose: int = 0) -> str:
+def getRole(role: Optional[str] = None, verbose: int = 0) -> str:
     """get current role.  Will check the following in order:
-    1. role_override
+    1. Given role (meant for override)
     2. default role file
     3. Existing valid token
     4. Use default
     """
-    if role_override:
-        return role_override
+    if role:
+        return role
 
     # Once we get to python 3.8, this can be changed to if (_role := getRole_from_default_role_file()): return _role,
     # and same for getRole_from_valid_token.  IMO, that's a bit clearer than this loop

--- a/lib/fake_ifdh.py
+++ b/lib/fake_ifdh.py
@@ -135,14 +135,16 @@ if __name__ == "__main__":
         if opts.command[0] in ("cp", "ls", "mkdir_p", "checkToken"):
             print(commands[opts.command[0]](*opts.cpargs[0]))  # type: ignore
         else:
-            result = commands[opts.command[0]](myrole, verbose=1)  # type: ignore
+            result = commands[opts.command[0]](role=myrole, verbose=1)  # type: ignore
             if result is not None:
                 print(result)
     except PermissionError as pe:
         sys.stderr.write(str(pe) + "\n")
         print("")
+        sys.exit(1)
     except KeyError:
         print(
             "An invalid command to fake_ifdh was given.  Please select from "
             f'one of the following: {", ".join(commands.keys())}'
         )
+        sys.exit(1)

--- a/tests/test_fake_ifdh_unit.py
+++ b/tests/test_fake_ifdh_unit.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 import os
+import pathlib
+import subprocess
 import sys
 
 import pytest
@@ -137,3 +139,41 @@ def test_ls(tmp_path):
     result = fake_ifdh.ls(str(test_dir))
     expected_files = {"file1.txt", "file2.txt", "file3.txt"}
     assert set(result) == expected_files
+
+
+class TestMain:
+    path_to_fake_ifdh = os.path.abspath(
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "lib/fake_ifdh.py")
+    )
+
+    @pytest.mark.unit
+    def test_main_invalid_command(self):
+        result = subprocess.run(
+            [self.path_to_fake_ifdh, "invalid_command"], capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert (
+            "An invalid command to fake_ifdh was given.  Please select from one of the following: getProxy, getToken, checkToken, cp, ls, mkdir_p, getRole"
+            in result.stdout
+        )
+
+    @pytest.mark.integration
+    def test_main_getToken_bad(self, monkeypatch):
+        monkeypatch.setenv("GROUP", "BOGUS")
+        result = subprocess.run(
+            [self.path_to_fake_ifdh, "getToken"], capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert "htgettoken: Failure getting token" in result.stderr
+        assert "BOGUS" in result.stderr
+
+    @pytest.mark.integration
+    def test_main_getToken(self, set_group_fermilab):
+        result = subprocess.run(
+            [self.path_to_fake_ifdh, "getToken"], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        bt_path = result.stdout.strip()
+        assert (
+            os.path.getsize(bt_path) > 0
+        )  # We should have a token here, so it should be a non-zero size file


### PR DESCRIPTION
As @marcmengel, @vitodb, and I discussed.

1. In `lib/creds.py:getRole`, change argument name from `role_override` to `role`.
2. In `lib/fake_ifdh.py`, make sure that if we're giving role to a random command-called function, we specify the `role` keyword. Also, if we have errors, exit with a non-zero exit code.
3. Added tests to check a few cases (incomplete, but covers the issue we found in testing).