### PR TITLE
Raise ValueError for invalid custom-action argument values (#599)

### DIFF
--- a/lib/get_parser.py
+++ b/lib/get_parser.py
@@ -73,7 +73,7 @@ class VerifyAndAddSkipCheck(argparse.Action):
     ) -> None:
         _supported_checks = SupportedSkipChecks.get_all_checks()
         if values not in _supported_checks:
-            raise TypeError(
+            raise ValueError(
                 f'Invalid argument to flag --skip-check: "{values}". Value must '
                 f"be one of the following: {_supported_checks}"
             )
@@ -99,7 +99,7 @@ class CheckIfValidSchedd(argparse.Action):
         vargs = {"group": group} if group is not None else {}
         valid_schedds = get_schedd_names(vargs, available_only=False)
         if values not in valid_schedds:
-            raise TypeError(
+            raise ValueError(
                 f"Invalid schedd specified: {values}.  Valid choices are {valid_schedds}"
             )
         setattr(namespace, self.dest, values)
@@ -167,7 +167,7 @@ class CheckExecutable(argparse.Action):
         regex = re.compile(r"file://(.+)")
         m = regex.match(str(values))
         if not m:
-            raise TypeError("executable must start with file://")
+            raise ValueError("executable must start with file://")
         executable_path = m.group(1)
         if not os.path.exists(executable_path):
             raise FileNotFoundError(

--- a/tests/test_get_parser_unit.py
+++ b/tests/test_get_parser_unit.py
@@ -544,8 +544,8 @@ class TestGetParserUnit:
     @pytest.mark.unit
     def test_verify_and_add_skip_check_single_invalid(self, skip_check_arg_parser):
         """This test makes sure that if we pass an invalid check to --skip-check, we
-        get a TypeError"""
-        with pytest.raises(TypeError, match="Invalid argument to flag --skip-check:"):
+        get a ValueError"""
+        with pytest.raises(ValueError, match="Invalid argument to flag --skip-check:"):
             skip_check_arg_parser.parse_args(["--skip-check", "ThisIsAFakeCheck"])
 
     @pytest.mark.unit
@@ -553,12 +553,12 @@ class TestGetParserUnit:
         self, skip_check_arg_parser, get_single_valid_check_to_skip
     ):
         """This test makes sure that if we pass a mix of valid and invalid checks
-        to --skip-check, we still get a TypeError"""
+        to --skip-check, we still get a ValueError"""
         valid_check = get_single_valid_check_to_skip
         if not valid_check:
             return
 
-        with pytest.raises(TypeError, match="Invalid argument to flag --skip-check:"):
+        with pytest.raises(ValueError, match="Invalid argument to flag --skip-check:"):
             skip_check_arg_parser.parse_args(
                 ["--skip-check", valid_check, "--skip-check", "ThisIsAFakeCheck"]
             )
@@ -584,8 +584,8 @@ class TestGetParserUnit:
     @pytest.mark.unit
     def test_schedd_for_testing_invalid(self, schedd_for_testing_arg_parser):
         """This test makes sure that if we give an invalid schedd to --schedd-for-testing,
-        we get a TypeError"""
-        with pytest.raises(TypeError, match="Invalid schedd specified"):
+        we get a ValueError"""
+        with pytest.raises(ValueError, match="Invalid schedd specified"):
             schedd_for_testing_arg_parser.parse_args(
                 ["--schedd-for-testing", "this_is_an_invalid_schedd.domain"]
             )
@@ -739,8 +739,8 @@ class TestGetParserUnit:
     @pytest.mark.unit
     def test_executable_arg_parser_invalid(self, executable_arg_parser):
         """This test makes sure that if we pass an invalid executable argument,
-        we get a TypeError"""
-        with pytest.raises(TypeError, match="executable must start with file://"):
+        we get a ValueError"""
+        with pytest.raises(ValueError, match="executable must start with file://"):
             executable_arg_parser.parse_args(["/bin/true"])
 
     @pytest.mark.unit


### PR DESCRIPTION
This addresses #599. The custom argparse actions in `lib/get_parser.py` were raising TypeError when a user passed a bad *value* to `--skip-check`, `--schedd-for-testing`, or the executable argument, but as the issue notes, the Python docs reserve TypeError for wrong types and ValueError for wrong values. I switched those three raises to ValueError and updated the matching expectations in `tests/test_get_parser_unit.py`.

I ran `pytest tests/test_get_parser_unit.py` for the affected cases: the --skip-check and executable checks are pure and pass with the change (and fail if I revert the raise back to TypeError, so the tests are actually exercising it). The invalid-schedd case goes through `get_schedd_names`, so I couldn't fully exercise it without a live collector, but the assertion change matches the other two. Thanks for taking a look.